### PR TITLE
Only migrate in the QA and EU release phases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,11 @@ db-migrate-down:
 db-seed:
 	@./script/seed.js
 	@$(DONE)
+
+# Database migration tasks specific to the release
+# phase in Heroku. This prevents migrating twice when
+# promoting to production (migrates in EU only)
+release-db:
+ifneq ($(REGION), US)
+	@make db-migrate-up
+endif

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: make run
-release: make release db-migrate-up
+release: make release release-db


### PR DESCRIPTION
This stops us from migrating twice on a promote to production, which could have side-effects.