### PR TITLE
Add in API keys and a simple permission model

### DIFF
--- a/data/migration/20171103134649_keys.js
+++ b/data/migration/20171103134649_keys.js
@@ -1,0 +1,27 @@
+'use strict';
+
+exports.up = async database => {
+
+	// Create the keys table
+	await database.schema.createTable('keys', table => {
+
+		// Meta information
+		table.string('id').unique().primary();
+		table.timestamp('created_at').defaultTo(database.fn.now());
+		table.timestamp('updated_at').defaultTo(database.fn.now());
+		table.timestamp('last_used_at').defaultTo(null);
+
+		// Key information
+		table.string('name').notNullable();
+		table.string('key').notNullable();
+		table.boolean('read').defaultTo(true);
+		table.boolean('write').defaultTo(false);
+		table.boolean('admin').defaultTo(false);
+
+	});
+
+};
+
+exports.down = async database => {
+	await database.schema.dropTable('keys');
+};

--- a/data/migration/20171103134649_keys.js
+++ b/data/migration/20171103134649_keys.js
@@ -9,11 +9,10 @@ exports.up = async database => {
 		table.string('id').unique().primary();
 		table.timestamp('created_at').defaultTo(database.fn.now());
 		table.timestamp('updated_at').defaultTo(database.fn.now());
-		table.timestamp('last_used_at').defaultTo(null);
 
 		// Key information
-		table.string('name').notNullable();
-		table.string('key').notNullable();
+		table.string('secret').notNullable();
+		table.string('description').notNullable();
 		table.boolean('read').defaultTo(true);
 		table.boolean('write').defaultTo(false);
 		table.boolean('admin').defaultTo(false);

--- a/data/seed/demo/keys.js
+++ b/data/seed/demo/keys.js
@@ -8,7 +8,7 @@ exports.seed = async database => {
 	await database('keys').insert([
 		{
 			id: '1b0a64e9-ce8c-4246-9356-3858e8b25804',
-			secret: await bcrypt.hash('8fa8ffe9-9cc8-413c-a86d-96e61e6ec8f4', 5),
+			secret: await bcrypt.hash('secret-key', 5), // Only for use in local demos
 			description: 'Origami admin access',
 			read: true,
 			write: true,
@@ -16,7 +16,7 @@ exports.seed = async database => {
 		},
 		{
 			id: 'd4169f7a-33e8-4596-bbe2-9fa669d993fd',
-			secret: await bcrypt.hash('696ccc15-883a-41f6-a2cf-4aefc4360292', 5),
+			secret: await bcrypt.hash('secret-key', 5), // Only for use in local demos
 			description: 'Example write access',
 			read: true,
 			write: true,
@@ -24,7 +24,7 @@ exports.seed = async database => {
 		},
 		{
 			id: 'd591f731-4a24-4ced-af9c-482df059f6ef',
-			secret: await bcrypt.hash('c47106f5-865b-4655-8bb5-2c237b534467', 5),
+			secret: await bcrypt.hash('secret-key', 5), // Only for use in local demos
 			description: 'Example read access',
 			read: true,
 			write: false,
@@ -32,7 +32,7 @@ exports.seed = async database => {
 		},
 		{
 			id: '86474c4d-d4dc-44c7-9d02-c2cdc667bb2c',
-			secret: await bcrypt.hash('f301745a-31c0-4fe1-a2d7-ad51d92167b7', 5),
+			secret: await bcrypt.hash('secret-key', 5), // Only for use in local demos
 			description: 'Example no access',
 			read: false,
 			write: false,

--- a/data/seed/demo/keys.js
+++ b/data/seed/demo/keys.js
@@ -1,0 +1,41 @@
+'use strict';
+
+exports.seed = async database => {
+
+	// Create some keys to test with
+	await database('keys').insert([
+		{
+			id: '1b0a64e9-ce8c-4246-9356-3858e8b25804',
+			name: 'Origami admin access',
+			key: '8fa8ffe9-9cc8-413c-a86d-96e61e6ec8f4',
+			read: true,
+			write: true,
+			admin: true
+		},
+		{
+			id: 'd4169f7a-33e8-4596-bbe2-9fa669d993fd',
+			name: 'Example write access',
+			key: '696ccc15-883a-41f6-a2cf-4aefc4360292',
+			read: true,
+			write: true,
+			admin: false
+		},
+		{
+			id: 'd591f731-4a24-4ced-af9c-482df059f6ef',
+			name: 'Example read access',
+			key: 'c47106f5-865b-4655-8bb5-2c237b534467',
+			read: true,
+			write: false,
+			admin: false
+		},
+		{
+			id: '86474c4d-d4dc-44c7-9d02-c2cdc667bb2c',
+			name: 'Example no access',
+			key: 'f301745a-31c0-4fe1-a2d7-ad51d92167b7',
+			read: false,
+			write: false,
+			admin: false
+		}
+	]);
+
+};

--- a/data/seed/demo/keys.js
+++ b/data/seed/demo/keys.js
@@ -1,37 +1,39 @@
 'use strict';
 
+const bcrypt = require('bcrypt');
+
 exports.seed = async database => {
 
 	// Create some keys to test with
 	await database('keys').insert([
 		{
 			id: '1b0a64e9-ce8c-4246-9356-3858e8b25804',
-			name: 'Origami admin access',
-			key: '8fa8ffe9-9cc8-413c-a86d-96e61e6ec8f4',
+			secret: await bcrypt.hash('8fa8ffe9-9cc8-413c-a86d-96e61e6ec8f4', 5),
+			description: 'Origami admin access',
 			read: true,
 			write: true,
 			admin: true
 		},
 		{
 			id: 'd4169f7a-33e8-4596-bbe2-9fa669d993fd',
-			name: 'Example write access',
-			key: '696ccc15-883a-41f6-a2cf-4aefc4360292',
+			secret: await bcrypt.hash('696ccc15-883a-41f6-a2cf-4aefc4360292', 5),
+			description: 'Example write access',
 			read: true,
 			write: true,
 			admin: false
 		},
 		{
 			id: 'd591f731-4a24-4ced-af9c-482df059f6ef',
-			name: 'Example read access',
-			key: 'c47106f5-865b-4655-8bb5-2c237b534467',
+			secret: await bcrypt.hash('c47106f5-865b-4655-8bb5-2c237b534467', 5),
+			description: 'Example read access',
 			read: true,
 			write: false,
 			admin: false
 		},
 		{
 			id: '86474c4d-d4dc-44c7-9d02-c2cdc667bb2c',
-			name: 'Example no access',
-			key: 'f301745a-31c0-4fe1-a2d7-ad51d92167b7',
+			secret: await bcrypt.hash('f301745a-31c0-4fe1-a2d7-ad51d92167b7', 5),
+			description: 'Example no access',
 			read: false,
 			write: false,
 			admin: false

--- a/lib/middleware/require-auth.js
+++ b/lib/middleware/require-auth.js
@@ -19,18 +19,20 @@ function requireAuth(level) {
 		throw new TypeError('Level is required, and must be one of the permission level symbols');
 	}
 	return async (request, response, next) => {
-		const userKey = request.headers['x-api-key'] || request.query.apiKey || null;
-		if (!userKey) {
+		const apiKey = request.headers['x-api-key'] || request.query.apiKey || null;
+		const apiSecret = request.headers['x-api-secret'] || request.query.apiSecret || null;
+		if (!apiKey || !apiSecret) {
 			return next(httpError(
 				401,
-				'An API key is required to use this service, please provide one in an X-Api-Key header'
+				'An API key/secret pair is required to use this service. Please provide X-Api-Key and X-Api-Secret headers'
 			));
 		}
-		const key = await request.app.model.Key.fetchByKey(userKey);
-		if (!key) {
+		const key = await request.app.model.Key.fetchById(apiKey);
+		const secretIsValid = (key ? await request.app.model.Key.compare(apiSecret, key.get('secret')) : false);
+		if (!key || !secretIsValid) {
 			return next(httpError(
 				401,
-				'The provided API key is invalid, it may have been revoked'
+				'Invalid credentials'
 			));
 		}
 		let authorised = false;

--- a/lib/middleware/require-auth.js
+++ b/lib/middleware/require-auth.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const httpError = require('http-errors');
+
+module.exports = requireAuth;
+
+module.exports.READ = Symbol('read');
+module.exports.WRITE = Symbol('write');
+module.exports.ADMIN = Symbol('admin');
+
+const levels = [
+	module.exports.READ,
+	module.exports.WRITE,
+	module.exports.ADMIN
+];
+
+function requireAuth(level) {
+	if (!levels.includes(level)) {
+		throw new TypeError('Level is required, and must be one of the permission level symbols');
+	}
+	return async (request, response, next) => {
+		const userKey = request.headers['x-api-key'] || request.query.apiKey || null;
+		if (!userKey) {
+			return next(httpError(
+				401,
+				'An API key is required to use this service, please provide one in an X-Api-Key header'
+			));
+		}
+		const key = await request.app.model.Key.fetchByKey(userKey);
+		if (!key) {
+			return next(httpError(
+				401,
+				'The provided API key is invalid, it may have been revoked'
+			));
+		}
+		let authorised = false;
+		switch (level) {
+			case module.exports.READ:
+				authorised = key.get('read');
+				break;
+			case module.exports.WRITE:
+				authorised = key.get('write');
+				break;
+			case module.exports.ADMIN:
+				authorised = key.get('admin');
+				break;
+		}
+		if (!authorised) {
+			return next(httpError(
+				403,
+				'You are not authorised to perform this request'
+			));
+		}
+		next();
+	};
+}

--- a/lib/routes/v1/repos.js
+++ b/lib/routes/v1/repos.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const cacheControl = require('@financial-times/origami-service').middleware.cacheControl;
+const requireAuth = require('../../middleware/require-auth');
 
 module.exports = app => {
 
@@ -9,7 +10,7 @@ module.exports = app => {
 	});
 
 	// List of all of the repositories
-	app.get('/v1/repos', cacheForSevenDays, async (request, response, next) => {
+	app.get('/v1/repos', requireAuth(requireAuth.READ), cacheForSevenDays, async (request, response, next) => {
 		try {
 			response.send({
 				repos: (await app.model.Version.fetchLatest()).map(version => {
@@ -22,7 +23,7 @@ module.exports = app => {
 	});
 
 	// Single repository
-	app.get('/v1/repos/:repoId', cacheForSevenDays, async (request, response, next) => {
+	app.get('/v1/repos/:repoId', requireAuth(requireAuth.READ), cacheForSevenDays, async (request, response, next) => {
 		try {
 			const repo = await app.model.Version.fetchLatestByRepoId(request.params.repoId);
 			if (!repo) {
@@ -37,7 +38,7 @@ module.exports = app => {
 	});
 
 	// List of all versions of a given repository
-	app.get('/v1/repos/:repoId/versions', cacheForSevenDays, async (request, response, next) => {
+	app.get('/v1/repos/:repoId/versions', requireAuth(requireAuth.READ), cacheForSevenDays, async (request, response, next) => {
 		try {
 			const versions = await app.model.Version.fetchByRepoId(request.params.repoId);
 			if (!versions || versions.length === 0) {

--- a/models/key.js
+++ b/models/key.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const uuid = require('uuid/v4');
+
+module.exports = initModel;
+
+function initModel(app) {
+
+	// Model prototypal methods
+	const Key = app.database.Model.extend({
+		tableName: 'keys',
+
+		// Model initialization
+		initialize() {
+
+			// When a model is created...
+			this.on('creating', () => {
+				// Fill out automatic fields
+				this.attributes.id = uuid();
+				this.attributes.key = uuid();
+				this.attributes.createdAt = new Date();
+			});
+
+			// When a model is saved...
+			this.on('saving', () => {
+				// Fill out automatic fields
+				this.attributes.updatedAt = new Date();
+				return this;
+			});
+
+		},
+
+		// Override default serialization so we can control
+		// what's output
+		serialize() {
+			return {
+				id: this.get('id'),
+				name: this.get('name'),
+				key: this.get('key'),
+				permissions: {
+					read: this.get('read'),
+					write: this.get('write'),
+					admin: this.get('admin')
+				},
+				lastUsed: this.get('last_used_at')
+			};
+		},
+
+	// Model static methods
+	}, {
+
+		// Fetch a key by its key property
+		fetchByKey(key) {
+			return Key.collection().query(qb => {
+				qb.where('key', key);
+				qb.orderBy('created_at', 'desc');
+			}).fetchOne();
+		}
+
+	});
+
+	// Add the model to the app
+	app.model.Key = Key;
+
+}

--- a/models/key.js
+++ b/models/key.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const bcrypt = require('bcrypt');
+const crypto = require('crypto');
 const uuid = require('uuid/v4');
 
 module.exports = initModel;
@@ -62,6 +63,12 @@ function initModel(app) {
 		// Check a key against a hashed key
 		compare(key, hash) {
 			return bcrypt.compare(key, hash);
+		},
+
+		// Generate a secure secret key
+		generateSecret() {
+			// See https://stackoverflow.com/a/14869745 for the thinking on this
+			return crypto.randomBytes(20).toString('hex');
 		},
 
 		// Fetch a key by its key property

--- a/models/version.js
+++ b/models/version.js
@@ -18,14 +18,14 @@ function initModel(app) {
 			this.on('creating', () => {
 				// Fill out automatic fields
 				this.attributes.id = uuid();
-				this.attributes.createdAt = new Date();
+				this.attributes.created_at = new Date();
 			});
 
 			// When a model is saved...
 			this.on('saving', () => {
 				// Fill out automatic fields
 				this.attributes.repo_id = uuidv5(this.attributes.url, uuidv5.URL);
-				this.attributes.updatedAt = new Date();
+				this.attributes.updated_at = new Date();
 				return this;
 			});
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,8 +73,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
       "version": "1.3.4",
@@ -173,6 +172,20 @@
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
       }
     },
     "argparse": {
@@ -314,6 +327,22 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "bcrypt": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-1.0.3.tgz",
+      "integrity": "sha512-pRyDdo73C8Nim3jwFJ7DWe3TZCgwDfWZ6nHS5LSdU77kWbj1frruvdndP02AOavtD4y8v6Fp2dolbHgp4SDrfg==",
+      "requires": {
+        "nan": "2.6.2",
+        "node-pre-gyp": "0.6.36"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+        }
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -333,6 +362,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
       "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "bluebird": {
       "version": "3.5.1",
@@ -590,8 +627,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
       "version": "1.9.0",
@@ -661,6 +697,11 @@
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
       }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -777,8 +818,7 @@
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-      "dev": true
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -814,6 +854,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
       "version": "1.1.1",
@@ -1401,8 +1446,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.1.2",
@@ -2303,6 +2347,27 @@
         }
       }
     },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "fstream-ignore": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+      "requires": {
+        "fstream": "1.0.11",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4"
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2313,6 +2378,41 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
     },
     "generic-pool": {
       "version": "2.5.4",
@@ -2486,6 +2586,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hawk": {
       "version": "6.0.2",
@@ -3471,6 +3576,33 @@
         "is-stream": "1.1.0"
       }
     },
+    "node-pre-gyp": {
+      "version": "0.6.36",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+      "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+      "requires": {
+        "mkdirp": "0.5.1",
+        "nopt": "4.0.1",
+        "npmlog": "4.1.2",
+        "rc": "1.2.1",
+        "request": "2.83.0",
+        "rimraf": "2.6.2",
+        "semver": "5.4.1",
+        "tar": "2.2.1",
+        "tar-pack": "3.4.1"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.4"
+          }
+        }
+      }
+    },
     "node.extend": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
@@ -3536,11 +3668,21 @@
         "path-key": "2.0.1"
       }
     },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
       "version": "11.2.1",
@@ -5191,8 +5333,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-keys": {
       "version": "1.0.11",
@@ -5287,8 +5428,16 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "p-finally": {
       "version": "1.0.0",
@@ -5506,8 +5655,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "proclaim": {
       "version": "3.5.0",
@@ -5647,7 +5795,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-      "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.4",
@@ -5658,8 +5805,7 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -5667,7 +5813,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -5853,7 +5998,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       },
@@ -5862,7 +6006,6 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -5912,8 +6055,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -5955,6 +6097,11 @@
         "send": "0.16.1"
       }
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -5984,8 +6131,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
       "version": "4.0.1",
@@ -6132,7 +6278,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -6159,8 +6304,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "superagent": {
       "version": "3.6.3",
@@ -6249,6 +6393,31 @@
             "has-flag": "2.0.0"
           }
         }
+      }
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
+    },
+    "tar-pack": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
+      "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
+      "requires": {
+        "debug": "2.6.9",
+        "fstream": "1.0.11",
+        "fstream-ignore": "1.0.5",
+        "once": "1.4.0",
+        "readable-stream": "2.3.3",
+        "rimraf": "2.6.2",
+        "tar": "2.2.1",
+        "uid-number": "0.0.6"
       }
     },
     "term-size": {
@@ -6400,6 +6569,11 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
     },
+    "uid-number": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
+    },
     "undefsafe": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
@@ -6468,8 +6642,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util-inspect": {
       "version": "0.1.8",
@@ -6556,6 +6729,34 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
         "isexe": "2.0.0"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "requires": {
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
       }
     },
     "widest-line": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@financial-times/health-check": "^1.2.1",
     "@financial-times/origami-service": "^2.1.3",
     "@financial-times/origami-service-makefile": "^4.0.0",
+    "bcrypt": "^1.0.3",
     "bookshelf": "^0.10.4",
     "dotenv": "^4.0.0",
     "heroku-node-settings": "^1.1.0",

--- a/test/integration/routes/v1-repos-(id)-versions.js
+++ b/test/integration/routes/v1-repos-(id)-versions.js
@@ -11,7 +11,8 @@ describe('GET /v1/repos/:repoId/versions', () => {
 		await database.seed(app, 'basic');
 		request = agent
 			.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions')
-			.set('X-Api-Key', 'mock-read-key');
+			.set('X-Api-Key', 'mock-read-key')
+			.set('X-Api-Secret', 'mock-read-secret');
 	});
 
 	it('responds with a 200 status', () => {
@@ -65,7 +66,8 @@ describe('GET /v1/repos/:repoId/versions', () => {
 			await database.seed(app, 'basic');
 			request = agent
 				.get('/v1/repos/not-an-id/versions')
-				.set('X-Api-Key', 'mock-read-key');
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
 		});
 
 		it('responds with a 404 status', () => {
@@ -78,7 +80,7 @@ describe('GET /v1/repos/:repoId/versions', () => {
 
 	});
 
-	describe('when no API key is provided', () => {
+	describe('when no API credentials are provided', () => {
 		let request;
 
 		beforeEach(async () => {
@@ -103,7 +105,8 @@ describe('GET /v1/repos/:repoId/versions', () => {
 			await database.seed(app, 'basic');
 			request = agent
 				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions')
-				.set('X-Api-Key', 'mock-no-key');
+				.set('X-Api-Key', 'mock-no-key')
+				.set('X-Api-Secret', 'mock-no-secret');
 		});
 
 		it('responds with a 403 status', () => {

--- a/test/integration/routes/v1-repos-(id)-versions.js
+++ b/test/integration/routes/v1-repos-(id)-versions.js
@@ -9,7 +9,9 @@ describe('GET /v1/repos/:repoId/versions', () => {
 
 	beforeEach(async () => {
 		await database.seed(app, 'basic');
-		request = agent.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions');
+		request = agent
+			.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions')
+			.set('X-Api-Key', 'mock-read-key');
 	});
 
 	it('responds with a 200 status', () => {
@@ -61,11 +63,51 @@ describe('GET /v1/repos/:repoId/versions', () => {
 
 		beforeEach(async () => {
 			await database.seed(app, 'basic');
-			request = agent.get('/v1/repos/not-an-id/versions');
+			request = agent
+				.get('/v1/repos/not-an-id/versions')
+				.set('X-Api-Key', 'mock-read-key');
 		});
 
 		it('responds with a 404 status', () => {
 			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when no API key is provided', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions');
+		});
+
+		it('responds with a 401 status', () => {
+			return request.expect(401);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions')
+				.set('X-Api-Key', 'mock-no-key');
+		});
+
+		it('responds with a 403 status', () => {
+			return request.expect(403);
 		});
 
 		it('responds with HTML', () => {

--- a/test/integration/routes/v1-repos-(id).js
+++ b/test/integration/routes/v1-repos-(id).js
@@ -11,7 +11,8 @@ describe('GET /v1/repos/:repoId', () => {
 		await database.seed(app, 'basic');
 		request = agent
 			.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d')
-			.set('X-Api-Key', 'mock-read-key');
+			.set('X-Api-Key', 'mock-read-key')
+			.set('X-Api-Secret', 'mock-read-secret');
 	});
 
 	it('responds with a 200 status', () => {
@@ -50,7 +51,8 @@ describe('GET /v1/repos/:repoId', () => {
 			await database.seed(app, 'basic');
 			request = agent
 				.get('/v1/repos/not-an-id')
-				.set('X-Api-Key', 'mock-read-key');
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
 		});
 
 		it('responds with a 404 status', () => {
@@ -63,7 +65,7 @@ describe('GET /v1/repos/:repoId', () => {
 
 	});
 
-	describe('when no API key is provided', () => {
+	describe('when no API credentials are provided', () => {
 		let request;
 
 		beforeEach(async () => {
@@ -88,7 +90,8 @@ describe('GET /v1/repos/:repoId', () => {
 			await database.seed(app, 'basic');
 			request = agent
 				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d')
-				.set('X-Api-Key', 'mock-no-key');
+				.set('X-Api-Key', 'mock-no-key')
+				.set('X-Api-Secret', 'mock-no-secret');
 		});
 
 		it('responds with a 403 status', () => {

--- a/test/integration/routes/v1-repos-(id).js
+++ b/test/integration/routes/v1-repos-(id).js
@@ -9,7 +9,9 @@ describe('GET /v1/repos/:repoId', () => {
 
 	beforeEach(async () => {
 		await database.seed(app, 'basic');
-		request = agent.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d');
+		request = agent
+			.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d')
+			.set('X-Api-Key', 'mock-read-key');
 	});
 
 	it('responds with a 200 status', () => {
@@ -46,11 +48,51 @@ describe('GET /v1/repos/:repoId', () => {
 
 		beforeEach(async () => {
 			await database.seed(app, 'basic');
-			request = agent.get('/v1/repos/not-an-id');
+			request = agent
+				.get('/v1/repos/not-an-id')
+				.set('X-Api-Key', 'mock-read-key');
 		});
 
 		it('responds with a 404 status', () => {
 			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when no API key is provided', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d');
+		});
+
+		it('responds with a 401 status', () => {
+			return request.expect(401);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d')
+				.set('X-Api-Key', 'mock-no-key');
+		});
+
+		it('responds with a 403 status', () => {
+			return request.expect(403);
 		});
 
 		it('responds with HTML', () => {

--- a/test/integration/routes/v1-repos.js
+++ b/test/integration/routes/v1-repos.js
@@ -11,7 +11,8 @@ describe('GET /v1/repos', () => {
 		await database.seed(app, 'basic');
 		request = agent
 			.get('/v1/repos')
-			.set('X-Api-Key', 'mock-read-key');
+			.set('X-Api-Key', 'mock-read-key')
+			.set('X-Api-Secret', 'mock-read-secret');
 	});
 
 	it('responds with a 200 status', () => {
@@ -50,7 +51,7 @@ describe('GET /v1/repos', () => {
 
 	});
 
-	describe('when no API key is provided', () => {
+	describe('when no API credentials are provided', () => {
 		let request;
 
 		beforeEach(async () => {
@@ -75,7 +76,8 @@ describe('GET /v1/repos', () => {
 			await database.seed(app, 'basic');
 			request = agent
 				.get('/v1/repos')
-				.set('X-Api-Key', 'mock-no-key');
+				.set('X-Api-Key', 'mock-no-key')
+				.set('X-Api-Secret', 'mock-no-secret');
 		});
 
 		it('responds with a 403 status', () => {

--- a/test/integration/routes/v1-repos.js
+++ b/test/integration/routes/v1-repos.js
@@ -9,7 +9,9 @@ describe('GET /v1/repos', () => {
 
 	beforeEach(async () => {
 		await database.seed(app, 'basic');
-		request = agent.get('/v1/repos');
+		request = agent
+			.get('/v1/repos')
+			.set('X-Api-Key', 'mock-read-key');
 	});
 
 	it('responds with a 200 status', () => {
@@ -44,6 +46,44 @@ describe('GET /v1/repos', () => {
 			assert.strictEqual(repo2.id, 'c990cb4b-c82b-5071-afb0-16149debc53d');
 			assert.strictEqual(repo2.name, 'o-mock-component');
 
+		});
+
+	});
+
+	describe('when no API key is provided', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent.get('/v1/repos');
+		});
+
+		it('responds with a 401 status', () => {
+			return request.expect(401);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos')
+				.set('X-Api-Key', 'mock-no-key');
+		});
+
+		it('responds with a 403 status', () => {
+			return request.expect(403);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
 		});
 
 	});

--- a/test/integration/seed/basic/keys.js
+++ b/test/integration/seed/basic/keys.js
@@ -1,0 +1,40 @@
+'use strict';
+
+// Create keys with different access levels
+exports.seed = async database => {
+	await database('keys').insert([
+		{
+			id: '1b0a64e9-ce8c-4246-9356-3858e8b25804',
+			name: 'mock admin key',
+			key: 'mock-admin-key',
+			read: true,
+			write: true,
+			admin: true
+		},
+		{
+			id: 'd4169f7a-33e8-4596-bbe2-9fa669d993fd',
+			name: 'mock write key',
+			key: 'mock-write-key',
+			read: true,
+			write: true,
+			admin: false
+		},
+		{
+			id: 'd591f731-4a24-4ced-af9c-482df059f6ef',
+			name: 'mock read key',
+			key: 'mock-read-key',
+			read: true,
+			write: false,
+			admin: false
+		},
+		{
+			id: '86474c4d-d4dc-44c7-9d02-c2cdc667bb2c',
+			name: 'mock no key',
+			key: 'mock-no-key',
+			read: false,
+			write: false,
+			admin: false
+		}
+	]);
+
+};

--- a/test/integration/seed/basic/keys.js
+++ b/test/integration/seed/basic/keys.js
@@ -1,36 +1,38 @@
 'use strict';
 
+const bcrypt = require('bcrypt');
+
 // Create keys with different access levels
 exports.seed = async database => {
 	await database('keys').insert([
 		{
-			id: '1b0a64e9-ce8c-4246-9356-3858e8b25804',
-			name: 'mock admin key',
-			key: 'mock-admin-key',
+			id: 'mock-admin-key',
+			secret: await bcrypt.hash('mock-admin-secret', 5),
+			description: 'mock admin key',
 			read: true,
 			write: true,
 			admin: true
 		},
 		{
-			id: 'd4169f7a-33e8-4596-bbe2-9fa669d993fd',
-			name: 'mock write key',
-			key: 'mock-write-key',
+			id: 'mock-write-key',
+			secret: await bcrypt.hash('mock-write-secret', 5),
+			description: 'mock write key',
 			read: true,
 			write: true,
 			admin: false
 		},
 		{
-			id: 'd591f731-4a24-4ced-af9c-482df059f6ef',
-			name: 'mock read key',
-			key: 'mock-read-key',
+			id: 'mock-read-key',
+			secret: await bcrypt.hash('mock-read-secret', 5),
+			description: 'mock read key',
 			read: true,
 			write: false,
 			admin: false
 		},
 		{
-			id: '86474c4d-d4dc-44c7-9d02-c2cdc667bb2c',
-			name: 'mock no key',
-			key: 'mock-no-key',
+			id: 'mock-no-key',
+			secret: await bcrypt.hash('mock-no-secret', 5),
+			description: 'mock no key',
 			read: false,
 			write: false,
 			admin: false

--- a/test/unit/lib/middleware/require-auth.js
+++ b/test/unit/lib/middleware/require-auth.js
@@ -1,0 +1,251 @@
+'use strict';
+
+const assert = require('proclaim');
+const sinon = require('sinon');
+
+describe('lib/middleware/require-auth', () => {
+	let mockKey;
+	let origamiService;
+	let requireAuth;
+
+	beforeEach(() => {
+		origamiService = require('../../mock/origami-service.mock');
+
+		mockKey = {
+			get: sinon.stub().returns(true)
+		};
+		origamiService.mockApp.model = {
+			Key: {
+				fetchByKey: sinon.stub().resolves(mockKey)
+			}
+		};
+
+		requireAuth = require('../../../../lib/middleware/require-auth');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(requireAuth);
+	});
+
+	it('has a `READ` property', () => {
+		assert.isTypeOf(requireAuth.READ, 'symbol');
+	});
+
+	it('has a `WRITE` property', () => {
+		assert.isTypeOf(requireAuth.WRITE, 'symbol');
+	});
+
+	it('has a `ADMIN` property', () => {
+		assert.isTypeOf(requireAuth.ADMIN, 'symbol');
+	});
+
+	describe('requireAuth(level)', () => {
+
+		it('returns a middleware function', () => {
+			assert.isFunction(requireAuth(requireAuth.READ));
+		});
+
+		describe('middleware(request, response, next)', () => {
+			let middleware;
+
+			beforeEach(() => {
+				middleware = requireAuth(requireAuth.READ);
+			});
+
+			describe('when a valid "X-Api-Key" header is set', () => {
+				let caughtError;
+
+				beforeEach(done => {
+					origamiService.mockRequest.headers['x-api-key'] = 'mock-api-key';
+					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
+						caughtError = error;
+						done();
+					});
+				});
+
+				it('fetches a key from the database', () => {
+					assert.calledOnce(origamiService.mockApp.model.Key.fetchByKey);
+					assert.calledWithExactly(origamiService.mockApp.model.Key.fetchByKey, 'mock-api-key');
+				});
+
+				it('gets the returned key permission that corresponds to `level`', () => {
+					assert.calledOnce(mockKey.get);
+					assert.calledWithExactly(mockKey.get, 'read');
+				});
+
+				it('calls `next` with no error', () => {
+					assert.isUndefined(caughtError);
+				});
+
+			});
+
+			describe('when a valid "apiKey" query parameter is set', () => {
+				let caughtError;
+
+				beforeEach(done => {
+					origamiService.mockRequest.query.apiKey = 'mock-api-key';
+					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
+						caughtError = error;
+						done();
+					});
+				});
+
+				it('fetches a key from the database', () => {
+					assert.calledOnce(origamiService.mockApp.model.Key.fetchByKey);
+					assert.calledWithExactly(origamiService.mockApp.model.Key.fetchByKey, 'mock-api-key');
+				});
+
+				it('gets the returned key permission that corresponds to `level`', () => {
+					assert.calledOnce(mockKey.get);
+					assert.calledWithExactly(mockKey.get, 'read');
+				});
+
+				it('calls `next` with no error', () => {
+					assert.isUndefined(caughtError);
+				});
+
+			});
+
+			describe('when an API key is not provided', () => {
+				let caughtError;
+
+				beforeEach(done => {
+					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
+						caughtError = error;
+						done();
+					});
+				});
+
+				it('does not fetch a key from the database', () => {
+					assert.notCalled(origamiService.mockApp.model.Key.fetchByKey);
+				});
+
+				it('calls `next` with a 401 error', () => {
+					assert.instanceOf(caughtError, Error);
+					assert.strictEqual(caughtError.status, 401);
+				});
+
+			});
+
+			describe('when an invalid "X-Api-Key" header is set', () => {
+				let caughtError;
+
+				beforeEach(done => {
+					origamiService.mockApp.model.Key.fetchByKey.resolves();
+					origamiService.mockRequest.headers['x-api-key'] = 'mock-api-key';
+					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
+						caughtError = error;
+						done();
+					});
+				});
+
+				it('attempts to fetch a key from the database', () => {
+					assert.calledOnce(origamiService.mockApp.model.Key.fetchByKey);
+					assert.calledWithExactly(origamiService.mockApp.model.Key.fetchByKey, 'mock-api-key');
+				});
+
+				it('calls `next` with a 401 error', () => {
+					assert.instanceOf(caughtError, Error);
+					assert.strictEqual(caughtError.status, 401);
+				});
+
+			});
+
+			describe('when the key doesn\'t have the permission required by `level`', () => {
+				let caughtError;
+
+				beforeEach(done => {
+					mockKey.get.returns(false);
+					origamiService.mockRequest.headers['x-api-key'] = 'mock-api-key';
+					middleware(origamiService.mockRequest, origamiService.mockResponse, error => {
+						caughtError = error;
+						done();
+					});
+				});
+
+				it('fetches a key from the database', () => {
+					assert.calledOnce(origamiService.mockApp.model.Key.fetchByKey);
+					assert.calledWithExactly(origamiService.mockApp.model.Key.fetchByKey, 'mock-api-key');
+				});
+
+				it('gets the returned key permission that corresponds to `level`', () => {
+					assert.calledOnce(mockKey.get);
+					assert.calledWithExactly(mockKey.get, 'read');
+				});
+
+				it('calls `next` with a 403 error', () => {
+					assert.instanceOf(caughtError, Error);
+					assert.strictEqual(caughtError.status, 403);
+				});
+
+			});
+
+		});
+
+		describe('when `level` is `requireAuth.READ`', () => {
+
+			describe('middleware(request, response, next)', () => {
+
+				beforeEach(done => {
+					origamiService.mockRequest.headers['x-api-key'] = 'mock-api-key';
+					requireAuth(requireAuth.READ)(origamiService.mockRequest, origamiService.mockResponse, done);
+				});
+
+				it('gets the returned key "read" permission', () => {
+					assert.calledOnce(mockKey.get);
+					assert.calledWithExactly(mockKey.get, 'read');
+				});
+
+			});
+
+		});
+
+		describe('when `level` is `requireAuth.WRITE`', () => {
+
+			describe('middleware(request, response, next)', () => {
+
+				beforeEach(done => {
+					origamiService.mockRequest.headers['x-api-key'] = 'mock-api-key';
+					requireAuth(requireAuth.WRITE)(origamiService.mockRequest, origamiService.mockResponse, done);
+				});
+
+				it('gets the returned key "write" permission', () => {
+					assert.calledOnce(mockKey.get);
+					assert.calledWithExactly(mockKey.get, 'write');
+				});
+
+			});
+
+		});
+
+		describe('when `level` is `requireAuth.ADMIN`', () => {
+
+			describe('middleware(request, response, next)', () => {
+
+				beforeEach(done => {
+					origamiService.mockRequest.headers['x-api-key'] = 'mock-api-key';
+					requireAuth(requireAuth.ADMIN)(origamiService.mockRequest, origamiService.mockResponse, done);
+				});
+
+				it('gets the returned key "admin" permission', () => {
+					assert.calledOnce(mockKey.get);
+					assert.calledWithExactly(mockKey.get, 'admin');
+				});
+
+			});
+
+		});
+
+		describe('when `level` is invalid', () => {
+
+			it('throws an error', () => {
+				assert.throws(() => {
+					requireAuth('not-valid');
+				}, /level is required, and must be one of the permission level symbols/i);
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/mock/origami-service.mock.js
+++ b/test/unit/mock/origami-service.mock.js
@@ -31,6 +31,7 @@ origamiService.middleware = {
 };
 
 module.exports.mockRequest = {
+	app: mockApp,
 	headers: {},
 	query: {},
 	params: {}


### PR DESCRIPTION
I've added in the required table and model for API keys. Currently they
have a simple permission model, each key can have any combination of the
following boolean permissions:

> **read:** view all repo data
> **write:** manually run new builds, purge, maybe others (not implemented)
> **admin:** grant and revoke access through API keys (not implemented)

There's also a middleware named `requireAuth` which can be used
per-route to enforce the permissions.

The endpoints require both an API key and an API secret. This means that
even if the database were compromised, there would be no need for key
rotation and we could safely restore to a previous backup.

The secrets are hashed using the [`bcrypt`](https://github.com/kelektiv/node.bcrypt.js) module. We reduce the number of
salt rounds required in order to speed up the service. Because of this
compromise, we should never use UUIDs as secrets: these could be guessable.
