### PR TITLE
Complete the API documentation

### DIFF
--- a/lib/routes/v1/docs/api.js
+++ b/lib/routes/v1/docs/api.js
@@ -8,10 +8,34 @@ module.exports = app => {
 		maxAge: '7d'
 	});
 
-	// API documentation page
-	app.get('/v1/docs/api', cacheForSevenDays, (request, response) => {
-		response.render('api', {
-			title: `API Reference - ${app.origami.options.name}`
+	// API documentation pages
+	const endpoints = [
+		{
+			path: '',
+			view: 'api/index',
+			title: 'API Reference'
+		},
+		{
+			path: '/authentication',
+			view: 'api/authentication',
+			title: 'Authentication - API Reference'
+		},
+		{
+			path: '/repositories',
+			view: 'api/repositories',
+			title: 'Repository Endpoints - API Reference'
+		},
+		{
+			path: '/keys',
+			view: 'api/keys',
+			title: 'API Key Endpoints - API Reference'
+		}
+	];
+	endpoints.forEach(endpoint => {
+		app.get(`/v1/docs/api${endpoint.path}`, cacheForSevenDays, (request, response) => {
+			response.render(endpoint.view, {
+				title: `${endpoint.title} - ${app.origami.options.name}`
+			});
 		});
 	});
 

--- a/lib/routes/v1/keys.js
+++ b/lib/routes/v1/keys.js
@@ -25,7 +25,7 @@ module.exports = app => {
 			});
 			await key.save();
 			response.status(201).send({
-				key: {
+				credentials: {
 					id: key.get('id'),
 					secret: secret
 				}

--- a/test/integration/routes/v1-keys.js
+++ b/test/integration/routes/v1-keys.js
@@ -153,17 +153,17 @@ describe('POST /v1/keys', () => {
 			response = (await request.then()).body;
 		});
 
-		it('has a `key` object property', () => {
-			assert.isObject(response.key);
+		it('has a `credentials` object property', () => {
+			assert.isObject(response.credentials);
 		});
 
 		it('includes the ID and secret of the new key', async () => {
 			const keys = await app.database.knex.select('*').from('keys').where({
 				description: 'mock description'
 			});
-			assert.isString(response.key.id);
-			assert.isString(response.key.secret);
-			assert.isTrue(await bcrypt.compare(response.key.secret, keys[0].secret));
+			assert.isString(response.credentials.id);
+			assert.isString(response.credentials.secret);
+			assert.isTrue(await bcrypt.compare(response.credentials.secret, keys[0].secret));
 		});
 
 	});

--- a/views/api/authentication.html
+++ b/views/api/authentication.html
@@ -1,0 +1,58 @@
+
+<div class="o-techdocs-container">
+	<div class="o-techdocs-layout">
+
+		<div class="o-techdocs-sidebar">
+			{{>navigation}}
+		</div>
+
+		<div class="o-techdocs-main o-techdocs-content">
+
+			<h1>Authentication</h1>
+
+			<p>
+				To authenticate with {{origami.options.name}}, you'll need an API key and secret.
+				You can get these by <a href="mailto:origami.support@ft.com">contacting the Origami team</a>.
+				Describe your use-case in detail so that we can assign your key appropriate permissions
+				(<code>READ</code>, <code>WRITE</code>, or <code>ADMIN</code>). The documentation
+				for each endpoint outlines which permission you'll need.
+			</p>
+
+			<p>
+				Once you have credentials, most API methods require you to provide the key and secret
+				in HTTP headers. You can use a query parameter rather than headers, but be careful
+				when using this approach as it's easier to accidentally expose your secret.
+			</p>
+
+			<p>
+				The headers or query parameters required by the service are:
+			</p>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<thead>
+						<tr>
+							<th>Header</th>
+							<th>Query Parameter</th>
+							<th>Value</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td><code>X-Api-Key</code></td>
+							<td><code>apiKey</code></td>
+							<td>The API key that was provided by the Origami team</td>
+						</tr>
+						<tr>
+							<td><code>X-Api-Secret</code></td>
+							<td><code>apiSecret</code></td>
+							<td>The API secret key that was provided by the Origami team</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+		</div>
+
+	</div>
+</div>

--- a/views/api/index.html
+++ b/views/api/index.html
@@ -1,0 +1,41 @@
+
+<div class="o-techdocs-container">
+	<div class="o-techdocs-layout">
+
+		<div class="o-techdocs-sidebar">
+			{{>navigation}}
+		</div>
+
+		<div class="o-techdocs-main o-techdocs-content">
+
+			<h1>API Reference</h1>
+
+			<p>
+				The API reference for {{origami.options.name}} is split into several sections:
+			</p>
+
+			<ul>
+				<li>
+					<p>
+						<a href="{{basePath}}v1/docs/api/authentication">Authentication</a>:<br/>
+						Learn how to get an API key and authenticate with {{origami.options.name}}
+					</p>
+				</li>
+				<li>
+					<p>
+						<a href="{{basePath}}v1/docs/api/repositories">Repository endpoints</a>:<br/>
+						List and manage repositories that have been ingested into the service
+					</p>
+				</li>
+				<li>
+					<p>
+						<a href="{{basePath}}v1/docs/api/keys">API Key endpoints</a>:<br/>
+						List and manage API keys that have access to the service
+					</p>
+				</li>
+			</ul>
+
+		</div>
+
+	</div>
+</div>

--- a/views/api/keys.html
+++ b/views/api/keys.html
@@ -1,0 +1,438 @@
+
+<div class="o-techdocs-container">
+	<div class="o-techdocs-layout">
+
+		<div class="o-techdocs-sidebar">
+			{{>navigation}}
+		</div>
+
+		<div class="o-techdocs-main o-techdocs-content">
+
+			<h1>API Key Endpoints</h1>
+
+			<p>
+				The API key endpoints are used to view and manage API keys to grant access to the
+				service. They respond and deal with one of the following entities:
+			</p>
+
+			<h2 id="entities">Entities</h2>
+
+			<h3 id="entity-key">Key Entity</h3>
+
+			<p>
+				Key entities represent API keys which have access to the service.
+				As JSON they look like this:
+			</p>
+
+			<pre><code class="json">{
+	// A unique identifier for the key, used in the X-Api-Key header
+	"id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+
+	// When the key was generated
+	"generated": "2017-11-06T12:09:43.276Z",
+
+	// A short human-readable description of the key
+	"description": "A read key for Origami dashboards",
+
+	// The permissions that this key grants when used to authenticate
+	"permissions": {
+		"read": true,
+		"write": false,
+		"admin": false
+	}
+}</code></pre>
+
+			<h3 id="entity-credentials">Credentials Entity</h3>
+
+			<p>
+				Credentials entities represent a full set of credentials (key and secret) which have
+				access to the service. As JSON they look like this:
+			</p>
+
+			<pre><code class="json">{
+	// A unique identifier for the key, used in the X-Api-Key header
+	"id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+
+	// The secret for the key, used in the X-Api-Secret header
+	"secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+}</code></pre>
+
+
+			<h2 id="get-v1-keys">Get all API keys</h2>
+
+			<p>
+				Get a list of all available API keys for this service as an array. This endpoint
+				responds with an array of <a href="#entity-key">Key entities</a>. This
+				endpoint requires the <code>ADMIN</code> permission.
+			</p>
+
+			<h3>Request</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Method</th>
+							<td>
+								<code>GET</code>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Path</th>
+							<td>
+								<code>/v1/keys</code>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>X-Api-Key</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+									<dt>X-Api-Secret</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+								</dl>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Response</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Status</th>
+							<td>
+								<code>200</code> on success<br/>
+								<code>401</code> if authentication failed<br/>
+								<code>403</code> if authorization failed
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>Content-Type</dt>
+									<dd>
+										<code>application/json</code> on success<br/>
+										<code>text/html</code> on error
+									</dd>
+								</dl>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Body</th>
+							<td>
+								<pre><code class="json">{
+	"keys": [
+		{
+			// Key entity
+		}
+	]
+}</code></pre>
+								<a href="#entity-key">(documentation on Key entities)</a>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Example <code>curl</code> command:</h3>
+
+			<pre><code class="bash">curl \
+	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
+	https://origami-repo-data.ft.com/v1/keys</code></pre>
+
+
+			<h2 id="get-v1-keys-(id)">Get an API key</h2>
+
+			<p>
+				Get a single API key for this service by ID. This endpoint responds with a
+				<a href="#entity-key">Key entity</a>. This endpoint requires the
+				<code>ADMIN</code> permission.
+			</p>
+
+			<h3>Request</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Method</th>
+							<td>
+								<code>GET</code>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Path</th>
+							<td>
+								<code>/v1/keys/<var>:key-id</var></code><br/>
+								(where <var>:key-id</var> is the unique identifier for a
+								<a href="#entity-repo">Key</a>)
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>X-Api-Key</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+									<dt>X-Api-Secret</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+								</dl>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Response</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Status</th>
+							<td>
+								<code>200</code> on success<br/>
+								<code>401</code> if authentication failed<br/>
+								<code>403</code> if authorization failed<br/>
+								<code>404</code> if a key matching <var>:key-id</var> does not exist
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>Content-Type</dt>
+									<dd>
+										<code>application/json</code> on success<br/>
+										<code>text/html</code> on error
+									</dd>
+								</dl>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Body</th>
+							<td>
+								<pre><code class="json">{
+	"key": [
+		// Key entity
+	]
+}</code></pre>
+								<a href="#entity-key">(documentation on Key entities)</a>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Example <code>curl</code> command:</h3>
+
+			<pre><code class="bash">curl \
+	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
+	https://origami-repo-data.ft.com/v1/keys/XXXXXX</code></pre>
+
+
+			<h2 id="post-v1-keys">Create an API key</h2>
+
+			<p>
+				Create a new API key which can be used to access the service. This endpoint accepts
+				key details and responds with a <a href="#entity-credentials">Credentials entity</a>: the new
+				API key and secret. This endpoint requires the <code>ADMIN</code> permission.
+			</p>
+
+			<p>
+				<strong aria-label="Warning">⚠️</strong> The API secret will only ever be output once
+				when the key is created. After this point it is hashed and unreadable even by the
+				service. Be sure to save the output somewhere secure, such as LastPass.
+			</p>
+
+			<h3>Request</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Method</th>
+							<td>
+								<code>POST</code>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Path</th>
+							<td>
+								<code>/v1/keys</code>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>Content-Type</dt>
+									<dd><code>application/json</code></dd>
+									<dt>X-Api-Key</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+									<dt>X-Api-Secret</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+								</dl>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Body</th>
+							<td>
+								<pre><code class="json">{
+	// A short human-readable description of the key (required)
+	"description": "A read key for Origami dashboards",
+
+	// The permissions that this key grants (optional)
+	"read": true,   // defaults to true
+	"write": false, // defaults to false
+	"admin": false  // defaults to false
+}</code></pre>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Response</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Status</th>
+							<td>
+								<code>201</code> on success<br/>
+								<code>400</code> if the request data is invalid or malformed<br/>
+								<code>401</code> if authentication failed<br/>
+								<code>403</code> if authorization failed
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>Content-Type</dt>
+									<dd>
+										<code>application/json</code> on success<br/>
+										<code>text/html</code> on error
+									</dd>
+								</dl>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Body</th>
+							<td>
+								<pre><code class="json">{
+	"credentials": {
+		// Credentials entity
+	}
+}</code></pre>
+								<a href="#entity-credentials">(documentation on Credentials entities)</a>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Example <code>curl</code> command:</h3>
+
+			<pre><code class="bash">curl -X POST \
+	-H 'Content-Type: application/json' -H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
+	-d '{"description": "A new API key", "read": true, "write": true, "admin": false}' \
+	https://origami-repo-data.ft.com/v1/keys</code></pre>
+
+
+			<h2 id="delete-v1-keys-(id)">Delete an API key</h2>
+
+			<p>
+				Delete a single API key from this service by ID. This endpoint requires the
+				<code>ADMIN</code> permission. Additionally, you are not permitted to delete the
+				same API key that you are currently authenticating with.
+			</p>
+
+			<h3>Request</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Method</th>
+							<td>
+								<code>DELETE</code>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Path</th>
+							<td>
+								<code>/v1/keys/<var>:key-id</var></code><br/>
+								(where <var>:key-id</var> is the unique identifier for a
+								<a href="#entity-repo">Key</a>)
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>X-Api-Key</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+									<dt>X-Api-Secret</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+								</dl>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Response</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Status</th>
+							<td>
+								<code>204</code> on success<br/>
+								<code>401</code> if authentication failed<br/>
+								<code>403</code> if authorization failed<br/>
+								<code>404</code> if a key matching <var>:key-id</var> does not exist
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>Content-Type</dt>
+									<dd>
+										Empty on success<br/>
+										<code>text/html</code> on error
+									</dd>
+								</dl>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Body</th>
+							<td>
+								Empty
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Example <code>curl</code> command:</h3>
+
+			<pre><code class="bash">curl -X DELETE \
+	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
+	https://origami-repo-data.ft.com/v1/keys/XXXXXX</code></pre>
+
+		</div>
+
+	</div>
+</div>

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -8,55 +8,14 @@
 
 		<div class="o-techdocs-main o-techdocs-content">
 
-			<h1>API Reference</h1>
-
-
-			<h2 id="authentication">Authentication</h2>
+			<h1>Repository Endpoints</h1>
 
 			<p>
-				To authenticate with {{origami.options.name}}, you'll need an API key and secret.
-				You can get these by <a href="mailto:origami.support@ft.com">contacting the Origami team</a>.
-				Describe your use-case in detail so that we can assign your key appropriate permissions
-				(<code>READ</code>, <code>WRITE</code>, or <code>ADMIN</code>). The documentation
-				for each endpoint below outlines which permission you'll need.
+				The repository endpoints are used to view and manage the repositories that have been
+				ingested into the service. They respond and deal with one of the following entities:
 			</p>
 
-			<p>
-				Once you have credentials, most API methods require you to provide the key and secret
-				in HTTP headers:
-			</p>
-
-			<div class="o-techdocs-table-wrapper">
-				<table>
-					<thead>
-						<tr>
-							<th>Header</th>
-							<th>Value</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td><code>X-Api-Key</code></td>
-							<td>The API key that was provided by the Origami team</td>
-						</tr>
-						<tr>
-							<td><code>X-Api-Secret</code></td>
-							<td>The API secret key that was provided by the Origami team</td>
-						</tr>
-					</tbody>
-				</table>
-			</div>
-
-			<h3>Example <code>curl</code> command:</h3>
-
-			<pre><code class="bash">curl -H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' https://origami-repo-data.ft.com/v1/repos</code></pre>
-
-
-			<h2 id="entities">Types of entity</h2>
-
-			<p>
-				{{origami.options.name}} responds with several different entity types:
-			</p>
+			<h2 id="entities">Entities</h2>
 
 			<h3 id="entity-repo">Repository Entity</h3>
 
@@ -120,31 +79,6 @@
 	"commitHash": "XXXXXX"
 }</code></pre>
 
-			<h3 id="entity-key">Key Entity</h3>
-
-			<p>
-				Key entities represent API keys which have access to the service.
-				As JSON they look like this:
-			</p>
-
-			<pre><code class="json">{
-	// A unique identifier for the key, used in the X-Api-Key header
-	"id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-
-	// When the key was generated
-	"generated": "2017-11-06T12:09:43.276Z",
-
-	// A short human-readable description of the key
-	"description": "A read key for Origami dashboards",
-
-	// The permissions that this key grants when used to authenticate
-	"permissions": {
-		"read": true,
-		"write": false,
-		"admin": false
-	}
-}</code></pre>
-
 
 			<h2 id="get-v1-repos">Get all repositories</h2>
 
@@ -166,20 +100,20 @@
 							</td>
 						</tr>
 						<tr>
+							<th scope="row">Path</th>
+							<td>
+								<code>/v1/repos</code>
+							</td>
+						</tr>
+						<tr>
 							<th scope="row">Headers</th>
 							<td>
 								<dl>
 									<dt>X-Api-Key</dt>
-									<dd>See <a href="#authentication">authentication docs</a></dd>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
 									<dt>X-Api-Secret</dt>
-									<dd>See <a href="#authentication">authentication docs</a></dd>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
 								</dl>
-							</td>
-						</tr>
-						<tr>
-							<th scope="row">Path</th>
-							<td>
-								<code>/v1/repos</code>
 							</td>
 						</tr>
 					</tbody>
@@ -221,6 +155,7 @@
 		}
 	]
 }</code></pre>
+								<a href="#entity-repo">(documentation on Repository entities)</a>
 							</td>
 						</tr>
 					</tbody>
@@ -229,10 +164,12 @@
 
 			<h3>Example <code>curl</code> command:</h3>
 
-			<pre><code class="bash">curl -H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' https://origami-repo-data.ft.com/v1/repos</code></pre>
+			<pre><code class="bash">curl \
+	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
+	https://origami-repo-data.ft.com/v1/repos</code></pre>
 
 
-			<h2 id="get-v1-repos-(id)">Get a single repository</h2>
+			<h2 id="get-v1-repos-(id)">Get a repository</h2>
 
 			<p>
 				Get a single Origami repository by ID. This endpoint responds with a
@@ -252,21 +189,21 @@
 							</td>
 						</tr>
 						<tr>
-							<th scope="row">Headers</th>
-							<td>
-								<dl>
-									<dt>X-Api-Key</dt>
-									<dd>See <a href="#authentication">authentication docs</a></dd>
-									<dt>X-Api-Secret</dt>
-									<dd>See <a href="#authentication">authentication docs</a></dd>
-								</dl>
-							</td>
-						</tr>
-						<tr>
 							<th scope="row">Path</th>
 							<td>
 								<code>/v1/repos/<var>:repo-id</var></code><br/>
 								(where <var>:repo-id</var> is the unique identifier for a <a href="#entity-repo">Repository</a>)
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>X-Api-Key</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+									<dt>X-Api-Secret</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+								</dl>
 							</td>
 						</tr>
 					</tbody>
@@ -307,6 +244,7 @@
 		// Repository entity
 	]
 }</code></pre>
+								<a href="#entity-repo">(documentation on Repository entities)</a>
 							</td>
 						</tr>
 					</tbody>
@@ -315,7 +253,100 @@
 
 			<h3>Example <code>curl</code> command:</h3>
 
-			<pre><code class="bash">curl -H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' https://origami-repo-data.ft.com/v1/repos/XXXXXX</code></pre>
+			<pre><code class="bash">curl \
+	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
+	https://origami-repo-data.ft.com/v1/repos/XXXXXX</code></pre>
+
+
+			<h2 id="get-v1-repos-(id)-versions">Get all versions for a repository</h2>
+
+			<p>
+				Get a list of all versions for an Origami repository as an array. This endpoint responds
+				with an array of <a href="#entity-version">Version entities</a>. This
+				endpoint requires the <code>READ</code> permission.
+			</p>
+
+			<h3>Request</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Method</th>
+							<td>
+								<code>GET</code>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Path</th>
+							<td>
+								<code>/v1/repos/<var>:repo-id</var>/versions</code><br/>
+								(where <var>:repo-id</var> is the unique identifier for a <a href="#entity-repo">Repository</a>)
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>X-Api-Key</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+									<dt>X-Api-Secret</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+								</dl>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Response</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Status</th>
+							<td>
+								<code>200</code> on success<br/>
+								<code>401</code> if authentication failed<br/>
+								<code>403</code> if authorization failed<br/>
+								<code>404</code> if a repo matching <var>:repo-id</var> does not exist
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>Content-Type</dt>
+									<dd>
+										<code>application/json</code> on success<br/>
+										<code>text/html</code> on error
+									</dd>
+								</dl>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Body</th>
+							<td>
+								<pre><code class="json">{
+	"versions": [
+		{
+			// Version entity
+		}
+	]
+}</code></pre>
+								<a href="#entity-version">(documentation on Version entities)</a>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Example <code>curl</code> command:</h3>
+
+			<pre><code class="bash">curl \
+	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
+	https://origami-repo-data.ft.com/v1/repos/XXXXXX/versions</code></pre>
 
 		</div>
 

--- a/views/partials/navigation.html
+++ b/views/partials/navigation.html
@@ -5,5 +5,16 @@
 	</li>
 	<li>
 		<a href="{{basePath}}v1/docs/api">API Reference</a>
+		<ul class="o-techdocs-nav o-techdocs-nav--sub">
+			<li>
+				<a href="{{basePath}}v1/docs/api/authentication">Authentication</a>
+			</li>
+			<li>
+				<a href="{{basePath}}v1/docs/api/repositories">Repository endpoints</a>
+			</li>
+			<li>
+				<a href="{{basePath}}v1/docs/api/keys">API Key endpoints</a>
+			</li>
+		</ul>
 	</li>
 </ul>


### PR DESCRIPTION
This includes splitting the API docs into multiple separate pages, which
keeps things more manageable.

This might be easier to review if you run it locally and read through the docs