### PR TITLE
Normalise semver versions in the database

### DIFF
--- a/data/migration/20171107161007_normalise-versions.js
+++ b/data/migration/20171107161007_normalise-versions.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const semver = require('semver');
+
+exports.up = async database => {
+
+	// Add a normalised version field to the versions table,
+	// and also start to index the version field as we're
+	// querying against it now
+	await database.schema.table('versions', table => {
+		table.string('version_normalised');
+		table.index('version');
+		table.index('version_normalised');
+	});
+
+	// Add normalised version numbers to existing versions
+	const versions = await database.select().from('versions');
+	for (const version of versions) {
+		await database('versions').where('id', version.id).update({
+			version_normalised: semver.valid(version.version)
+		});
+	}
+
+};
+
+exports.down = async database => {
+
+	// Remove the normalised version field from the versions table
+	// and drop the index for the version field
+	await database.schema.table('versions', table => {
+		table.dropColumn('version_normalised');
+		table.dropIndex('version');
+	});
+
+};

--- a/data/seed/demo/example-component.js
+++ b/data/seed/demo/example-component.js
@@ -23,6 +23,7 @@ exports.seed = async database => {
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
 			version: 'v1.0.0',
+			version_normalised: '1.0.0',
 			commit_hash: 'bca9e0e599880484ba2c0245096e58b3977f34fc',
 			manifests: JSON.stringify({
 				about: null,
@@ -59,6 +60,7 @@ exports.seed = async database => {
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
 			version: 'v1.1.0',
+			version_normalised: '1.1.0',
 			commit_hash: '2bd8b4de9e0c213aff6769aba6d8d5d820b5d434',
 			manifests: JSON.stringify({
 				about: null,
@@ -95,6 +97,7 @@ exports.seed = async database => {
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
 			version: 'v2.0.0',
+			version_normalised: '2.0.0',
 			commit_hash: 'd440c97c5664c56058f57e9d27d9b81944e1f226',
 			manifests: JSON.stringify({
 				about: null,

--- a/data/seed/demo/example-node-module.js
+++ b/data/seed/demo/example-node-module.js
@@ -21,6 +21,7 @@ exports.seed = async database => {
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
 			version: 'v1.0.0',
+			version_normalised: '1.0.0',
 			commit_hash: '071a20f7e49b6fcf29c1080140d599c8c60b71b6',
 			manifests: JSON.stringify({
 				about: null,
@@ -51,6 +52,7 @@ exports.seed = async database => {
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
 			version: 'v1.1.0',
+			version_normalised: '1.1.0',
 			commit_hash: '64a7ab36ee875404a57f62c2fe0bea528603f022',
 			manifests: JSON.stringify({
 				about: null,

--- a/models/version.js
+++ b/models/version.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const semver = require('semver');
 const uuid = require('uuid/v4');
 const uuidv5 = require('uuid/v5');
 
@@ -25,6 +26,7 @@ function initModel(app) {
 			this.on('saving', () => {
 				// Fill out automatic fields
 				this.attributes.repo_id = uuidv5(this.attributes.url, uuidv5.URL);
+				this.attributes.version_normalised = Version.normaliseSemver(this.attributes.version);
 				this.attributes.updated_at = new Date();
 				return this;
 			});
@@ -160,8 +162,13 @@ function initModel(app) {
 			return Version.collection().query(qb => {
 				qb.select('*');
 				qb.where('repo_id', repoId);
-				qb.where('version', versionNumber);
+				qb.where('version_normalised', Version.normaliseSemver(versionNumber));
 			}).fetchOne();
+		},
+
+		// Normalise a semver version
+		normaliseSemver(semverVersion) {
+			return semver.valid(semverVersion);
 		}
 
 	});

--- a/test/integration/seed/basic/component.js
+++ b/test/integration/seed/basic/component.js
@@ -14,6 +14,7 @@ exports.seed = async database => {
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
 			version: 'v1.0.0',
+			version_normalised: '1.0.0',
 			commit_hash: 'mock-hash-1',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
@@ -29,6 +30,7 @@ exports.seed = async database => {
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
 			version: 'v1.1.0',
+			version_normalised: '1.1.0',
 			commit_hash: 'mock-hash-2',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
@@ -44,6 +46,7 @@ exports.seed = async database => {
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
 			version: 'v2.0.0',
+			version_normalised: '2.0.0',
 			commit_hash: 'mock-hash-3',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})

--- a/test/integration/seed/basic/service.js
+++ b/test/integration/seed/basic/service.js
@@ -14,6 +14,7 @@ exports.seed = async database => {
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
 			version: 'v1.0.0',
+			version_normalised: '1.0.0',
 			commit_hash: 'mock-hash-1',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
@@ -29,6 +30,7 @@ exports.seed = async database => {
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
 			version: 'v2.0.0',
+			version_normalised: '2.0.0',
 			commit_hash: 'mock-hash-2',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
@@ -44,6 +46,7 @@ exports.seed = async database => {
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
 			version: 'v2.1.0',
+			version_normalised: '2.1.0',
 			commit_hash: 'mock-hash-3',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})


### PR DESCRIPTION
This allows for easier querying later. We need to keep both the
non-normalised and normalised versions for different reasons:

We'll use the non-normalised version to fetch details about a GitHub
release. For this, we need to match the tag on GitHub _exactly_.

We'll use the normalised version to power semver-based URLs and so that
database rows can be sorted by this field reliably. E.g. we don't end up
with the following:

  - 1.0.0
  - 1.3.0
  - v1.2.0