### PR TITLE
Rename the version fields

### DIFF
--- a/data/migration/20171108092727_rename-versions-fields.js
+++ b/data/migration/20171108092727_rename-versions-fields.js
@@ -1,0 +1,33 @@
+'use strict';
+
+exports.up = async database => {
+
+	// Rename the version columns
+	await database.schema.table('versions', table => {
+		table.dropIndex('version');
+		table.dropIndex('version_normalised');
+
+		table.renameColumn('version', 'tag');
+		table.renameColumn('version_normalised', 'version');
+
+		table.index('tag');
+		table.index('version');
+	});
+
+};
+
+exports.down = async database => {
+
+	// Rename the version columns back
+	await database.schema.table('versions', table => {
+		table.dropIndex('tag');
+		table.dropIndex('version');
+
+		table.renameColumn('version', 'version_normalised');
+		table.renameColumn('tag', 'version');
+
+		table.index('version');
+		table.index('version_normalised');
+	});
+
+};

--- a/data/seed/demo/example-component.js
+++ b/data/seed/demo/example-component.js
@@ -22,8 +22,8 @@ exports.seed = async database => {
 			url: 'https://github.com/Financial-Times/o-example-component',
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
-			version: 'v1.0.0',
-			version_normalised: '1.0.0',
+			tag: 'v1.0.0',
+			version: '1.0.0',
 			commit_hash: 'bca9e0e599880484ba2c0245096e58b3977f34fc',
 			manifests: JSON.stringify({
 				about: null,
@@ -59,8 +59,8 @@ exports.seed = async database => {
 			url: 'https://github.com/Financial-Times/o-example-component',
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
-			version: 'v1.1.0',
-			version_normalised: '1.1.0',
+			tag: 'v1.1.0',
+			version: '1.1.0',
 			commit_hash: '2bd8b4de9e0c213aff6769aba6d8d5d820b5d434',
 			manifests: JSON.stringify({
 				about: null,
@@ -96,8 +96,8 @@ exports.seed = async database => {
 			url: 'https://github.com/Financial-Times/o-example-component',
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
-			version: 'v2.0.0',
-			version_normalised: '2.0.0',
+			tag: 'v2.0.0',
+			version: '2.0.0',
 			commit_hash: 'd440c97c5664c56058f57e9d27d9b81944e1f226',
 			manifests: JSON.stringify({
 				about: null,

--- a/data/seed/demo/example-node-module.js
+++ b/data/seed/demo/example-node-module.js
@@ -20,8 +20,8 @@ exports.seed = async database => {
 			url: 'https://github.com/Financial-Times/node-example-module',
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
-			version: 'v1.0.0',
-			version_normalised: '1.0.0',
+			tag: 'v1.0.0',
+			version: '1.0.0',
 			commit_hash: '071a20f7e49b6fcf29c1080140d599c8c60b71b6',
 			manifests: JSON.stringify({
 				about: null,
@@ -51,8 +51,8 @@ exports.seed = async database => {
 			url: 'https://github.com/Financial-Times/node-example-module',
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
-			version: 'v1.1.0',
-			version_normalised: '1.1.0',
+			tag: 'v1.1.0',
+			version: '1.1.0',
 			commit_hash: '64a7ab36ee875404a57f62c2fe0bea528603f022',
 			manifests: JSON.stringify({
 				about: null,

--- a/models/version.js
+++ b/models/version.js
@@ -26,7 +26,7 @@ function initModel(app) {
 			this.on('saving', () => {
 				// Fill out automatic fields
 				this.attributes.repo_id = uuidv5(this.attributes.url, uuidv5.URL);
-				this.attributes.version_normalised = Version.normaliseSemver(this.attributes.version);
+				this.attributes.version = Version.normaliseSemver(this.attributes.tag);
 				this.attributes.updated_at = new Date();
 				return this;
 			});
@@ -162,7 +162,7 @@ function initModel(app) {
 			return Version.collection().query(qb => {
 				qb.select('*');
 				qb.where('repo_id', repoId);
-				qb.where('version_normalised', Version.normaliseSemver(versionNumber));
+				qb.where('version', Version.normaliseSemver(versionNumber));
 			}).fetchOne();
 		},
 

--- a/test/integration/routes/v1-repos-(id)-versions.js
+++ b/test/integration/routes/v1-repos-(id)-versions.js
@@ -41,19 +41,19 @@ describe('GET /v1/repos/:repoId/versions', () => {
 			assert.isObject(version1);
 			assert.strictEqual(version1.id, '9e4e450d-3b70-4672-b459-f297d434add6');
 			assert.strictEqual(version1.name, 'o-mock-component');
-			assert.strictEqual(version1.version, 'v2.0.0');
+			assert.strictEqual(version1.version, '2.0.0');
 
 			const version2 = response.versions[1];
 			assert.isObject(version2);
 			assert.strictEqual(version2.id, 'b2bdfae1-cc6f-4433-9a2f-8a4b762cda71');
 			assert.strictEqual(version2.name, 'o-mock-component');
-			assert.strictEqual(version2.version, 'v1.1.0');
+			assert.strictEqual(version2.version, '1.1.0');
 
 			const version3 = response.versions[2];
 			assert.isObject(version3);
 			assert.strictEqual(version3.id, '5bdc1cb5-19f1-4afe-883b-83c822fbbde0');
 			assert.strictEqual(version3.name, 'o-mock-component');
-			assert.strictEqual(version3.version, 'v1.0.0');
+			assert.strictEqual(version3.version, '1.0.0');
 
 		});
 

--- a/test/integration/seed/basic/component.js
+++ b/test/integration/seed/basic/component.js
@@ -13,8 +13,8 @@ exports.seed = async database => {
 			url: 'https://github.com/Financial-Times/o-mock-component',
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
-			version: 'v1.0.0',
-			version_normalised: '1.0.0',
+			tag: 'v1.0.0',
+			version: '1.0.0',
 			commit_hash: 'mock-hash-1',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
@@ -29,8 +29,8 @@ exports.seed = async database => {
 			url: 'https://github.com/Financial-Times/o-mock-component',
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
-			version: 'v1.1.0',
-			version_normalised: '1.1.0',
+			tag: 'v1.1.0',
+			version: '1.1.0',
 			commit_hash: 'mock-hash-2',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
@@ -45,8 +45,8 @@ exports.seed = async database => {
 			url: 'https://github.com/Financial-Times/o-mock-component',
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
-			version: 'v2.0.0',
-			version_normalised: '2.0.0',
+			tag: 'v2.0.0',
+			version: '2.0.0',
 			commit_hash: 'mock-hash-3',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})

--- a/test/integration/seed/basic/service.js
+++ b/test/integration/seed/basic/service.js
@@ -13,8 +13,8 @@ exports.seed = async database => {
 			url: 'https://github.com/Financial-Times/mock-service',
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
-			version: 'v1.0.0',
-			version_normalised: '1.0.0',
+			tag: 'v1.0.0',
+			version: '1.0.0',
 			commit_hash: 'mock-hash-1',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
@@ -29,8 +29,8 @@ exports.seed = async database => {
 			url: 'https://github.com/Financial-Times/mock-service',
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
-			version: 'v2.0.0',
-			version_normalised: '2.0.0',
+			tag: 'v2.0.0',
+			version: '2.0.0',
 			commit_hash: 'mock-hash-2',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
@@ -45,8 +45,8 @@ exports.seed = async database => {
 			url: 'https://github.com/Financial-Times/mock-service',
 			support_email: 'origami.support@ft.com',
 			support_channel: '#ft-origami',
-			version: 'v2.1.0',
-			version_normalised: '2.1.0',
+			tag: 'v2.1.0',
+			version: '2.1.0',
 			commit_hash: 'mock-hash-3',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -38,7 +38,7 @@
 	"type": "module",
 
 	// The latest version of the repo to be published
-	"version": "v1.1.0",
+	"version": "1.1.0",
 
 	// A description and keywords for the repo, based on one of the JSON manifests in it
 	"description": "An example Node.js module",
@@ -73,7 +73,7 @@
 	"id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 
 	// The semver version number that corresponds to this release
-	"version": "v1.1.0",
+	"version": "1.1.0",
 
 	// The commit hash that corresponds to this release
 	"commitHash": "XXXXXX"


### PR DESCRIPTION
The field names `version` and `version_normalised` weren't really
describing the data that should be in them. I've renamed as follows:

  - `version -> tag`: as this will contain the exact tag that was found
    on the repository. This is non-normative. We will use this to fetch
    information about the tag from GitHub

  - `version_normalised -> version`: the value we will expose on all of
    the endpoints and for querying the database. It is normalised
    through semver