### PR TITLE
Add a setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Now you can access the app over HTTP on port `8080`: [http://localhost:8080/](ht
 
 We configure Origami Repo Data using environment variables. In development, configurations are set in a `.env` file. In production, these are set through Heroku config. Further documentation on the available options can be found in the [Origami Service documentation][service-options].
 
+### One time only
+
+  * `ENABLE_SETUP_STEP`: Set to `true` in order to allow the creation of an admin key using the `/v1/setup` endpoint. Once a key has been created this way, this configuration should be removed for security reasons.
+
 ### Required everywhere
 
   * `DATABASE_URL`: A PostgreSQL connection string, with write permission on a database

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ const options = {
 	database: process.env.DATABASE_URL || 'postgres://localhost:5432/origami-repo-data',
 	log: console,
 	name: 'Origami Repo Data',
-	workers: process.env.WEB_CONCURRENCY || 1
+	workers: process.env.WEB_CONCURRENCY || 1,
+	enableSetupStep: !!process.env.ENABLE_SETUP_STEP
 };
 
 throng({

--- a/lib/routes/v1/index.js
+++ b/lib/routes/v1/index.js
@@ -4,15 +4,52 @@ const cacheControl = require('@financial-times/origami-service').middleware.cach
 
 module.exports = app => {
 
-	const cacheForSevenDays = cacheControl({
-		maxAge: '7d'
+	const neverCache = cacheControl({
+		maxAge: 0
 	});
 
 	// Home page
-	app.get('/v1/', cacheForSevenDays, (request, response) => {
-		response.render('index', {
-			title: app.origami.options.name
-		});
+	app.get('/v1/', neverCache, async (request, response, next) => {
+		try {
+			let setupCredentials;
+			if (app.origami.options.enableSetupStep) {
+				setupCredentials = await setupService(app);
+			}
+			response.render('index', {
+				title: app.origami.options.name,
+				setupCredentials: setupCredentials
+			});
+		} catch (error) {
+			next(error);
+		}
 	});
+
+	// Get the setup credentials
+	async function setupService(app) {
+
+		// If any keys already exist in the database,
+		// return no credentials
+		const existingKeys = await app.model.Key.fetchAll();
+		if (existingKeys.length) {
+			return;
+		}
+
+		// Create a new admin key and output the credentials
+		const secret = app.model.Key.generateSecret();
+		const key = new app.model.Key({
+			secret: secret,
+			description: 'Origami admin access',
+			read: true,
+			write: true,
+			admin: true
+		});
+		await key.save();
+
+		return {
+			id: key.get('id'),
+			secret: secret
+		};
+
+	}
 
 };

--- a/public/main.css
+++ b/public/main.css
@@ -15,3 +15,9 @@ table dl,
 .o-techdocs-content table pre {
 	margin: 0;
 }
+
+/* aside overrides */
+.o-techdocs-card__content p,
+.o-techdocs-card__content pre {
+	margin: 0;
+}

--- a/views/index.html
+++ b/views/index.html
@@ -7,8 +7,38 @@
 		</div>
 
 		<div class="o-techdocs-main o-techdocs-content">
+
 			<h1>Get information about Origami repositories</h1>
+
 			<p><strong>⚠️ This is a work in progress ⚠️</strong></p>
+
+			{{#if origami.options.enableSetupStep}}
+				<div class="o-techdocs-card o-techdocs-card--sev1">
+					<div class="o-techdocs-card__context">
+						<div class="o-techdocs-card__heading">
+							<div class="o-techdocs-card__title">Service Set Up</div>
+						</div>
+					</div>
+					<div class="o-techdocs-card__content">
+						{{#if setupCredentials}}
+							<p>
+								The API key and secret below will only ever be output once. Do not
+								refresh this page or navigate away until you've saved the credentials
+								somewhere secure, such as LastPass.
+							</p>
+							<pre><code class="nohighlight"><b>API Key:</b> {{setupCredentials.id}}
+<b>API Secret:</b> {{setupCredentials.secret}}</code></pre>
+						{{else}}
+							<p>
+								Please remove the <code>ENABLE_SETUP_STEP</code> environment
+								variable from the service configuration.
+							</p>
+						{{/if}}
+
+					</div>
+				</div>
+			{{/if}}
+
 		</div>
 
 	</div>


### PR DESCRIPTION
We use an environment variable to enable the setup step. When this is
active, we output the admin key and secret just once on the home page of
the service:

![screencapture-localhost-8080-v1-1510309059905](https://user-images.githubusercontent.com/138944/32653651-7ca5d31e-c600-11e7-92fc-a93688a0872e.png)

We then prompt the user to remove the environment variable:

![screencapture-localhost-8080-v1-1510309070965](https://user-images.githubusercontent.com/138944/32653655-824c67f6-c600-11e7-93c8-658d0663deb7.png)
