### PR TITLE
Add an ingestion queue processor

### DIFF
--- a/lib/ingestion-queue-processor.js
+++ b/lib/ingestion-queue-processor.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const idlePollInterval = (30 * 1000); // 30 seconds
+
+module.exports = class IngestionQueueProcessor {
+
+	constructor(app) {
+		this.app = app;
+		this.logger = app.origami.options.log;
+		this.Ingestion = app.model.Ingestion;
+		this.Version = app.model.Version;
+	}
+
+	async start() {
+		this.fetchNextIngestion();
+	}
+
+	async fetchNextIngestion() {
+		let ingestion;
+		try {
+			ingestion = await this.Ingestion.fetchLatestAndMarkAsRunning();
+
+			// We have an ingestion, we can process it now
+			if (ingestion) {
+				this.log({
+					type: 'attempt',
+					url: ingestion.get('url'),
+					tag: ingestion.get('tag')
+				});
+
+				// Attempt to create a new version from the ingestion
+				const version = await this.Version.createFromIngestion(ingestion);
+				this.log({
+					type: 'success',
+					url: ingestion.get('url'),
+					tag: ingestion.get('tag'),
+					version: version.get('id')
+				});
+
+				// Destroy the completed ingestion
+				await ingestion.destroy();
+
+			// No more ingestions found, we just set a timer
+			// to poll for more soon (and return)
+			} else {
+				return setTimeout(() => {
+					this.fetchNextIngestion();
+				}, idlePollInterval);
+			}
+		} catch (error) {
+			const log = {
+				type: 'error',
+				message: error.message
+			};
+			if (ingestion) {
+				log.url = ingestion.get('url');
+				log.tag = ingestion.get('tag');
+
+				ingestion.set('ingestion_attempts', ingestion.get('ingestion_attempts') + 1);
+				ingestion.set('ingestion_started_at', null);
+
+				await ingestion.save();
+			}
+			this.log(log);
+		}
+
+		// Do it all over again
+		return this.fetchNextIngestion();
+	}
+
+	log(data) {
+		data.date = (new Date()).toISOString();
+		const dataString = Object.entries(data).map(([key, value]) => {
+			return `${key}="${value}"`;
+		}).join(' ');
+		this.logger.info(`Ingestion Queue: ${dataString}`);
+	}
+
+};

--- a/lib/ingestion-queue-processor.js
+++ b/lib/ingestion-queue-processor.js
@@ -65,7 +65,9 @@ module.exports = class IngestionQueueProcessor {
 		}
 
 		// Do it all over again
-		return this.fetchNextIngestion();
+		setTimeout(() => {
+			this.fetchNextIngestion();
+		}, 100);
 	}
 
 	log(data) {

--- a/lib/service.js
+++ b/lib/service.js
@@ -2,6 +2,7 @@
 
 const bookshelf = require('bookshelf');
 const healthChecks = require('./health-checks');
+const IngestionQueueProcessor = require('./ingestion-queue-processor');
 const knex = require('knex');
 const morgan = require('morgan');
 const origamiService = require('@financial-times/origami-service');
@@ -36,6 +37,9 @@ function service(options) {
 	app.database.plugin('virtuals');
 	app.model = {};
 	loadModels(app);
+
+	app.ingestionQueueProcessor = new IngestionQueueProcessor(app);
+	app.ingestionQueueProcessor.start();
 
 	return app;
 }

--- a/models/ingestion.js
+++ b/models/ingestion.js
@@ -121,8 +121,8 @@ function initModel(app) {
 
 					// This is the implementation of the exponential backoff.
 					// The ingestion will be attempted at longer and longer
-					// intervals (10 seconds to the power of the number of
-					// attempts made so far)
+					// intervals (10 seconds time 2 to the power of the number
+					// of attempts made so far)
 					qb.where(app.database.knex.raw('created_at + (interval \'10 seconds\' * power(2, ingestion_attempts)) <= now()'));
 
 					// Get the oldest ingestion first, so that things hang

--- a/models/ingestion.js
+++ b/models/ingestion.js
@@ -14,7 +14,7 @@ function initModel(app) {
 		}).required(),
 		tag: joi.semver().valid().required(),
 		ingestion_attempts: joi.number().integer(),
-		ingestion_started_at: joi.date()
+		ingestion_started_at: joi.date().allow(null)
 	});
 
 	// Model prototypal methods
@@ -104,9 +104,52 @@ function initModel(app) {
 			return Ingestion.collection().query(qb => {
 				qb.where('id', ingestionId);
 			}).fetchOne();
+		},
+
+		// Fetch the latest ingestion that isn't running,
+		// and mark it as running
+		async fetchLatestAndMarkAsRunning() {
+			// We use transactions here to ensure the update is never triggered twice
+			// if multiple dynos are accessing the entry in the database
+			return app.database.transaction(async transaction => {
+				const ingestion = await Ingestion.collection().query(qb => {
+
+					// The ingestion must not be currently running, and must have
+					// fewer attempts than the maximum
+					qb.where('ingestion_started_at', null);
+					qb.where('ingestion_attempts', '<', Ingestion.maximumAttempts);
+
+					// This is the implementation of the exponential backoff.
+					// The ingestion will be attempted at longer and longer
+					// intervals (10 seconds to the power of the number of
+					// attempts made so far)
+					qb.where(app.database.knex.raw('created_at + (interval \'10 seconds\' * power(2, ingestion_attempts)) <= now()'));
+
+					// Get the oldest ingestion first, so that things hang
+					// around for less time
+					qb.orderBy('updated_at', 'asc');
+
+					qb.transacting(transaction);
+					qb.forUpdate();
+				}).fetchOne();
+				if (!ingestion) {
+					return null;
+				}
+
+				// Mark the ingestion as started
+				ingestion.set('ingestion_started_at', new Date());
+				await ingestion.save(null, {
+					transacting: transaction
+				});
+				return ingestion;
+			});
 		}
 
 	});
+
+	// The maximum number of attempts to make on
+	// an ingestion
+	Ingestion.maximumAttempts = 10;
 
 	// Add the model to the app
 	app.model.Ingestion = Ingestion;

--- a/models/version.js
+++ b/models/version.js
@@ -77,7 +77,7 @@ function initModel(app) {
 
 			// Get a description of the version, falling back through different manifests
 			description() {
-				const manifests = this.get('manifests');
+				const manifests = this.get('manifests') || {};
 
 				// Order: origami, about, package, bower
 				if (manifests.origami && manifests.origami.description) {
@@ -97,7 +97,7 @@ function initModel(app) {
 
 			// Get keywords for the version, falling back through different manifests
 			keywords() {
-				const manifests = this.get('manifests');
+				const manifests = this.get('manifests') || {};
 				let keywords;
 
 				// Order: origami, package, bower
@@ -169,6 +169,22 @@ function initModel(app) {
 		// Normalise a semver version
 		normaliseSemver(semverVersion) {
 			return semver.valid(semverVersion);
+		},
+
+		// Create a version based on an Ingestion
+		async createFromIngestion(ingestion) {
+
+			// TODO get the full information from GitHub
+			const version = new Version({
+				name: ingestion.get('url').replace(/^https?:\/\/(www\.)?github.com\/|\/$/gi, ''),
+				url: ingestion.get('url'),
+				tag: ingestion.get('tag'),
+				commit_hash: 'TODO'
+			});
+
+			// Save and return the version
+			await version.save();
+			return version;
 		}
 
 	});

--- a/test/unit/lib/ingestion-queue-processor.test.js
+++ b/test/unit/lib/ingestion-queue-processor.test.js
@@ -1,0 +1,263 @@
+'use strict';
+
+const assert = require('proclaim');
+const sinon = require('sinon');
+
+describe('lib/ingestion-queue-processor', () => {
+	let app;
+	let IngestionQueueProcessor;
+	let mockIngestion;
+	let mockVersion;
+
+	beforeEach(() => {
+		app = require('../mock/origami-service.mock').mockApp;
+		mockIngestion = {
+			destroy: sinon.stub().resolves(),
+			get: sinon.stub(),
+			save: sinon.stub().resolves(),
+			set: sinon.stub()
+		};
+		mockVersion = {
+			get: sinon.stub()
+		};
+		app.model = {
+			Ingestion: {
+				fetchLatestAndMarkAsRunning: sinon.stub().resolves(mockIngestion)
+			},
+			Version: {
+				createFromIngestion: sinon.stub().resolves(mockVersion)
+			}
+		};
+
+		IngestionQueueProcessor = require('../../../lib/ingestion-queue-processor');
+	});
+
+	it('exports a class constructor', () => {
+		assert.isFunction(IngestionQueueProcessor);
+		assert.throws(() => IngestionQueueProcessor(), /constructor ingestionqueueprocessor/i); // eslint-disable-line new-cap
+	});
+
+	describe('new IngestionQueueProcessor(app)', () => {
+		let instance;
+
+		beforeEach(() => {
+			instance = new IngestionQueueProcessor(app);
+		});
+
+		it('has an `app` property set to passed in app', () => {
+			assert.strictEqual(instance.app, app);
+		});
+
+		it('has a `logger` property set to the application logger', () => {
+			assert.strictEqual(instance.logger, app.origami.options.log);
+		});
+
+		it('has an `Ingestion` property set to the Ingestion model', () => {
+			assert.strictEqual(instance.Ingestion, app.model.Ingestion);
+		});
+
+		it('has a `Version` property set to the Version model', () => {
+			assert.strictEqual(instance.Version, app.model.Version);
+		});
+
+		describe('.start()', () => {
+
+			beforeEach(() => {
+				instance.fetchNextIngestion = sinon.spy();
+				instance.start();
+			});
+
+			it('calls the `fetchNextIngestion` method', () => {
+				assert.calledOnce(instance.fetchNextIngestion);
+				assert.calledWithExactly(instance.fetchNextIngestion);
+			});
+
+		});
+
+		describe('.fetchNextIngestion()', () => {
+			let fetchNextIngestion;
+
+			beforeEach(async () => {
+				sinon.stub(global, 'setTimeout');
+
+				mockIngestion.get.withArgs('url').returns('mock-ingestion-url');
+				mockIngestion.get.withArgs('tag').returns('mock-ingestion-tag');
+				mockVersion.get.withArgs('id').returns('mock-version-id');
+				instance.log = sinon.spy();
+
+				// We need to grab the function and then mock it because otherwise
+				// it will recurse infinitely
+				fetchNextIngestion = instance.fetchNextIngestion.bind(instance);
+				instance.fetchNextIngestion = sinon.spy();
+
+				await fetchNextIngestion();
+			});
+
+			afterEach(() => {
+				global.setTimeout.restore();
+			});
+
+			it('fetches the next ingestion from the database', () => {
+				assert.calledOnce(instance.Ingestion.fetchLatestAndMarkAsRunning);
+				assert.calledWithExactly(instance.Ingestion.fetchLatestAndMarkAsRunning);
+			});
+
+			it('logs an attempt', () => {
+				assert.calledWith(instance.log, {
+					type: 'attempt',
+					url: 'mock-ingestion-url',
+					tag: 'mock-ingestion-tag'
+				});
+			});
+
+			it('creates a new version based on the ingestion', () => {
+				assert.calledOnce(instance.Version.createFromIngestion);
+				assert.calledWithExactly(instance.Version.createFromIngestion, mockIngestion);
+			});
+
+			it('logs the version creation', () => {
+				assert.calledWith(instance.log, {
+					type: 'success',
+					url: 'mock-ingestion-url',
+					tag: 'mock-ingestion-tag',
+					version: 'mock-version-id'
+				});
+			});
+
+			it('destroys the successful ingestion', () => {
+				assert.calledOnce(mockIngestion.destroy);
+			});
+
+			it('recurses immediately', () => {
+				assert.calledOnce(instance.fetchNextIngestion);
+				assert.calledWithExactly(instance.fetchNextIngestion);
+			});
+
+			describe('when no ingestions are in the database', () => {
+
+				beforeEach(async () => {
+					instance.Ingestion.fetchLatestAndMarkAsRunning.resetHistory();
+					instance.Ingestion.fetchLatestAndMarkAsRunning.resolves(null);
+					instance.Version.createFromIngestion.resetHistory();
+					instance.fetchNextIngestion.reset();
+					await fetchNextIngestion();
+				});
+
+				it('attempts to fetch the next ingestion from the database', () => {
+					assert.calledOnce(instance.Ingestion.fetchLatestAndMarkAsRunning);
+					assert.calledWithExactly(instance.Ingestion.fetchLatestAndMarkAsRunning);
+				});
+
+				it('does not create a new version', () => {
+					assert.notCalled(instance.Version.createFromIngestion);
+				});
+
+				it('does not recurse immediately', () => {
+					assert.notCalled(instance.fetchNextIngestion);
+				});
+
+				it('sets a timeout to recurse later', () => {
+					assert.calledOnce(global.setTimeout);
+					assert.isFunction(global.setTimeout.firstCall.args[0]);
+					assert.strictEqual(global.setTimeout.firstCall.args[1], 30000);
+					global.setTimeout.firstCall.args[0]();
+					assert.calledOnce(instance.fetchNextIngestion);
+					assert.calledWithExactly(instance.fetchNextIngestion);
+				});
+
+			});
+
+			describe('when the version creation fails', () => {
+				let creationError;
+
+				beforeEach(async () => {
+					creationError = new Error('mock creation error');
+					instance.Version.createFromIngestion.resetHistory();
+					instance.Version.createFromIngestion.rejects(creationError);
+					instance.fetchNextIngestion.reset();
+					mockIngestion.get.withArgs('ingestion_attempts').returns(1);
+					await fetchNextIngestion();
+				});
+
+				it('logs the failure', () => {
+					assert.calledWith(instance.log, {
+						type: 'error',
+						message: 'mock creation error',
+						url: 'mock-ingestion-url',
+						tag: 'mock-ingestion-tag'
+					});
+				});
+
+				it('increments the ingestion attempts', () => {
+					assert.calledWithExactly(mockIngestion.set, 'ingestion_attempts', 2);
+				});
+
+				it('nullifies the ingestion start date', () => {
+					assert.calledWithExactly(mockIngestion.set, 'ingestion_started_at', null);
+				});
+
+				it('saves the ingestion', () => {
+					assert.calledOnce(mockIngestion.save);
+					assert.calledWithExactly(mockIngestion.save);
+				});
+
+				it('recurses immediately', () => {
+					assert.calledOnce(instance.fetchNextIngestion);
+					assert.calledWithExactly(instance.fetchNextIngestion);
+				});
+
+			});
+
+			describe('when the ingestion fetch fails', () => {
+				let fetchError;
+
+				beforeEach(async () => {
+					fetchError = new Error('mock fetch error');
+					instance.Ingestion.fetchLatestAndMarkAsRunning.resetHistory();
+					instance.Ingestion.fetchLatestAndMarkAsRunning.rejects(fetchError);
+					instance.fetchNextIngestion.reset();
+					await fetchNextIngestion();
+				});
+
+				it('logs the failure', () => {
+					assert.calledWith(instance.log, {
+						type: 'error',
+						message: 'mock fetch error'
+					});
+				});
+
+				it('recurses immediately', () => {
+					assert.calledOnce(instance.fetchNextIngestion);
+					assert.calledWithExactly(instance.fetchNextIngestion);
+				});
+
+			});
+
+		});
+
+		describe('.log(data)', () => {
+
+			beforeEach(() => {
+				sinon.stub(global, 'Date').returns({
+					toISOString: sinon.stub().returns('mock iso string')
+				});
+				instance.log({
+					mockKey1: 'mock-value-1',
+					mockKey2: 'mock-value-2'
+				});
+			});
+
+			afterEach(() => {
+				global.Date.restore();
+			});
+
+			it('logs a prefixed message with the data serialised into a string', () => {
+				assert.calledOnce(instance.logger.info);
+				assert.calledWithExactly(instance.logger.info, 'Ingestion Queue: mockKey1="mock-value-1" mockKey2="mock-value-2" date="mock iso string"');
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/lib/ingestion-queue-processor.test.js
+++ b/test/unit/lib/ingestion-queue-processor.test.js
@@ -128,7 +128,11 @@ describe('lib/ingestion-queue-processor', () => {
 				assert.calledOnce(mockIngestion.destroy);
 			});
 
-			it('recurses immediately', () => {
+			it('sets a timeout to recurse', () => {
+				assert.calledOnce(global.setTimeout);
+				assert.isFunction(global.setTimeout.firstCall.args[0]);
+				assert.strictEqual(global.setTimeout.firstCall.args[1], 100);
+				global.setTimeout.firstCall.args[0]();
 				assert.calledOnce(instance.fetchNextIngestion);
 				assert.calledWithExactly(instance.fetchNextIngestion);
 			});
@@ -136,6 +140,7 @@ describe('lib/ingestion-queue-processor', () => {
 			describe('when no ingestions are in the database', () => {
 
 				beforeEach(async () => {
+					global.setTimeout.resetHistory();
 					instance.Ingestion.fetchLatestAndMarkAsRunning.resetHistory();
 					instance.Ingestion.fetchLatestAndMarkAsRunning.resolves(null);
 					instance.Version.createFromIngestion.resetHistory();
@@ -171,6 +176,7 @@ describe('lib/ingestion-queue-processor', () => {
 				let creationError;
 
 				beforeEach(async () => {
+					global.setTimeout.resetHistory();
 					creationError = new Error('mock creation error');
 					instance.Version.createFromIngestion.resetHistory();
 					instance.Version.createFromIngestion.rejects(creationError);
@@ -201,7 +207,11 @@ describe('lib/ingestion-queue-processor', () => {
 					assert.calledWithExactly(mockIngestion.save);
 				});
 
-				it('recurses immediately', () => {
+				it('sets a timeout to recurse', () => {
+					assert.calledOnce(global.setTimeout);
+					assert.isFunction(global.setTimeout.firstCall.args[0]);
+					assert.strictEqual(global.setTimeout.firstCall.args[1], 100);
+					global.setTimeout.firstCall.args[0]();
 					assert.calledOnce(instance.fetchNextIngestion);
 					assert.calledWithExactly(instance.fetchNextIngestion);
 				});
@@ -212,6 +222,7 @@ describe('lib/ingestion-queue-processor', () => {
 				let fetchError;
 
 				beforeEach(async () => {
+					global.setTimeout.resetHistory();
 					fetchError = new Error('mock fetch error');
 					instance.Ingestion.fetchLatestAndMarkAsRunning.resetHistory();
 					instance.Ingestion.fetchLatestAndMarkAsRunning.rejects(fetchError);
@@ -226,7 +237,11 @@ describe('lib/ingestion-queue-processor', () => {
 					});
 				});
 
-				it('recurses immediately', () => {
+				it('sets a timeout to recurse', () => {
+					assert.calledOnce(global.setTimeout);
+					assert.isFunction(global.setTimeout.firstCall.args[0]);
+					assert.strictEqual(global.setTimeout.firstCall.args[1], 100);
+					global.setTimeout.firstCall.args[0]();
 					assert.calledOnce(instance.fetchNextIngestion);
 					assert.calledWithExactly(instance.fetchNextIngestion);
 				});

--- a/test/unit/lib/service.test.js
+++ b/test/unit/lib/service.test.js
@@ -10,6 +10,7 @@ describe('lib/service', () => {
 	let basePath;
 	let bookshelf;
 	let healthChecks;
+	let IngestionQueueProcessor;
 	let knex;
 	let morgan;
 	let service;
@@ -27,6 +28,9 @@ describe('lib/service', () => {
 
 		healthChecks = require('../mock/health-checks.mock');
 		mockery.registerMock('./health-checks', healthChecks);
+
+		IngestionQueueProcessor = require('../mock/ingestion-queue-processor.mock');
+		mockery.registerMock('./ingestion-queue-processor', IngestionQueueProcessor);
 
 		knex = require('../mock/knex.mock');
 		mockery.registerMock('knex', knex);
@@ -232,6 +236,16 @@ describe('lib/service', () => {
 			requireAll.secondCall.args[0].resolve(model);
 			assert.calledOnce(model);
 			assert.calledWithExactly(model, origamiService.mockApp);
+		});
+
+		it('creates an ingestion queue processor', () => {
+			assert.calledOnce(IngestionQueueProcessor);
+			assert.calledWithExactly(IngestionQueueProcessor, origamiService.mockApp);
+			assert.calledWithNew(IngestionQueueProcessor);
+		});
+
+		it('starts the created ingestion queue processor', () => {
+			assert.calledOnce(IngestionQueueProcessor.mockIngestionQueueProcessor.start);
 		});
 
 		it('returns the created application', () => {

--- a/test/unit/mock/ingestion-queue-processor.mock.js
+++ b/test/unit/mock/ingestion-queue-processor.mock.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const IngestionQueueProcessor = module.exports = sinon.stub();
+
+const mockIngestionQueueProcessor = module.exports.mockIngestionQueueProcessor = {
+	start: sinon.spy()
+};
+
+IngestionQueueProcessor.returns(mockIngestionQueueProcessor);

--- a/test/unit/mock/origami-service.mock.js
+++ b/test/unit/mock/origami-service.mock.js
@@ -12,7 +12,8 @@ const mockApp = module.exports.mockApp = {
 	locals: {},
 	origami: {
 		options: {
-			mockOptions: true
+			mockOptions: true,
+			log: require('./log.mock')
 		}
 	},
 	set: sinon.stub(),


### PR DESCRIPTION
This processes the ingestion queue, adding new repos/versions to the
database. Currently not implemented:

  - Version details are not currently got from GitHub, we use the data
    we have available for now. This will come soon.

  - We don't alert when an ingestion reaches the maximum number of
    attempts. This will be added in a later PR.

  - We don't look out for long running ingestions, where a start time is
    longer than (for example) an hour ago. This could occur on the rare
    occasion when a dyno restarts mid-way through an ingestion. This
    will be added in a later PR.