### PR TITLE
Add garbage collection for the ingestion queue

### DIFF
--- a/lib/ingestion-queue-processor.js
+++ b/lib/ingestion-queue-processor.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const idlePollInterval = (30 * 1000); // 30 seconds
+const garbagePollInterval = (15 * 60 * 1000); // 15 minutes
 
 module.exports = class IngestionQueueProcessor {
 
@@ -13,6 +14,7 @@ module.exports = class IngestionQueueProcessor {
 
 	async start() {
 		this.fetchNextIngestion();
+		this.collectGarbage();
 	}
 
 	async fetchNextIngestion() {
@@ -82,6 +84,47 @@ module.exports = class IngestionQueueProcessor {
 		setTimeout(() => {
 			this.fetchNextIngestion();
 		}, pollInterval);
+	}
+
+	async collectGarbage() {
+		try {
+
+			// Clear over-attempted ingestions
+			const overAttemptedIngestions = await this.Ingestion.fetchOverAttempted();
+			for (const overAttemptedIngestion of overAttemptedIngestions.toArray()) {
+				this.log({
+					type: 'garbage-collection',
+					message: 'Ingestion attempted too many times',
+					url: overAttemptedIngestion.get('url'),
+					tag: overAttemptedIngestion.get('tag')
+				});
+				await overAttemptedIngestion.destroy();
+			}
+
+			// Allow long-running ingestions to be attempted again
+			const overRunningIngestions = await this.Ingestion.fetchOverRunning();
+			for (const overRunningIngestion of overRunningIngestions.toArray()) {
+				this.log({
+					type: 'garbage-collection',
+					message: 'Ingestion ran for too long',
+					url: overRunningIngestion.get('url'),
+					tag: overRunningIngestion.get('tag')
+				});
+				overRunningIngestion.set('ingestion_started_at', null);
+				await overRunningIngestion.save();
+			}
+
+		} catch (error) {
+			this.log({
+				type: 'garbage-collection-error',
+				message: error.message
+			});
+		}
+
+		// Do it all over again
+		setTimeout(() => {
+			this.collectGarbage();
+		}, garbagePollInterval);
 	}
 
 	log(data) {


### PR DESCRIPTION
We now perform garbage collection on the ingestion queue every 15
minutes. The following actions are performed:

  1. Fetch all ingestions that have been attempted 10 or more times and
     remove them from the database

  2. Fetch all ingestions that have been running for 15 minutes or more,
     as this is an indication that they have failed or the application
     restarted before they could complete. Nullify their start time so
     that they are attempted again