### PR TITLE
Mask API keys in the logs

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -8,6 +8,7 @@ const knex = require('knex');
 const morgan = require('morgan');
 const origamiService = require('@financial-times/origami-service');
 const requireAll = require('require-all');
+const url = require('url');
 
 module.exports = service;
 
@@ -19,9 +20,28 @@ function service(options) {
 	options.about = require('../about.json');
 	options.defaultLayout = 'main';
 
+	// Add an auth token to Morgan, for logging safe authentication details (no secrets)
 	morgan.token('auth', (request, response, field = 'id') => {
 		return (request.authenticatedKey ? request.authenticatedKey.get(field) : 'none');
 	});
+
+	// Replace the default Morgan URL token, as this exposes API keys and secrets in the querystring.
+	// The original is here: https://github.com/expressjs/morgan/blob/b29fc884dd836960fabe65fe71db988bcb867371/index.js#L212
+	morgan.token('url', request => {
+		const mask = 'XXXXX';
+		const requestUrl = url.parse(request.originalUrl || request.url, true);
+		if (requestUrl.query.apiKey) {
+			requestUrl.query.apiKey = mask;
+		}
+		if (requestUrl.query.apiSecret) {
+			requestUrl.query.apiSecret = mask;
+		}
+		// In order to use the `query` object in URL formatting, we need to delete the `search` property:
+		// https://nodejs.org/docs/latest/api/url.html#url_url_format_urlobject
+		delete requestUrl.search;
+		return url.format(requestUrl);
+	});
+
 	if (options.requestLogFormat === undefined) {
 		options.requestLogFormat = `${morgan.combined} auth=":auth/:auth[description]"`;
 	}

--- a/test/unit/lib/service.test.js
+++ b/test/unit/lib/service.test.js
@@ -105,8 +105,7 @@ describe('lib/service', () => {
 		});
 
 		it('creates a new morgan token named "auth"', () => {
-			assert.calledOnce(morgan.token);
-			assert.calledWith(morgan.token, 'auth');
+			assert.calledWith(morgan.token.firstCall, 'auth');
 			assert.isFunction(morgan.token.firstCall.args[1]);
 		});
 
@@ -161,6 +160,90 @@ describe('lib/service', () => {
 
 				it('returns "none"', () => {
 					assert.strictEqual(returnValue, 'none');
+				});
+
+			});
+
+		});
+
+		it('overrides the morgan token named "url"', () => {
+			assert.calledWith(morgan.token.secondCall, 'url');
+			assert.isFunction(morgan.token.secondCall.args[1]);
+		});
+
+		describe('morgan "url" token', () => {
+			let urlToken;
+			let mockRequest;
+			let returnValue;
+
+			beforeEach(() => {
+				mockRequest = {
+					originalUrl: '/mock-original-url'
+				};
+				urlToken = morgan.token.secondCall.args[1];
+				returnValue = urlToken(mockRequest);
+			});
+
+			it('returns the value of the request `originalUrl` property', () => {
+				assert.strictEqual(returnValue, '/mock-original-url');
+			});
+
+			describe('when the `originalUrl` property is not set', () => {
+
+				beforeEach(() => {
+					mockRequest = {
+						url: '/mock-url'
+					};
+					returnValue = urlToken(mockRequest);
+				});
+
+				it('returns the value of the request `url` property', () => {
+					assert.strictEqual(returnValue, '/mock-url');
+				});
+
+			});
+
+			describe('when the request querystring contains an `apiKey` property', () => {
+
+				beforeEach(() => {
+					mockRequest = {
+						url: '/mock-url?foo=bar&apiKey=123456&bar=baz'
+					};
+					returnValue = urlToken(mockRequest);
+				});
+
+				it('returns the request URL with that key masked', () => {
+					assert.strictEqual(returnValue, '/mock-url?foo=bar&apiKey=XXXXX&bar=baz');
+				});
+
+			});
+
+			describe('when the request querystring contains an `apiSecret` property', () => {
+
+				beforeEach(() => {
+					mockRequest = {
+						url: '/mock-url?foo=bar&apiSecret=123456&bar=baz'
+					};
+					returnValue = urlToken(mockRequest);
+				});
+
+				it('returns the request URL with that key masked', () => {
+					assert.strictEqual(returnValue, '/mock-url?foo=bar&apiSecret=XXXXX&bar=baz');
+				});
+
+			});
+
+			describe('when the request querystring contains an `apiSecret` property', () => {
+
+				beforeEach(() => {
+					mockRequest = {
+						url: '/mock-url?foo=bar&apiKey=123456&apiSecret=7890&bar=baz'
+					};
+					returnValue = urlToken(mockRequest);
+				});
+
+				it('returns the request URL with that key masked', () => {
+					assert.strictEqual(returnValue, '/mock-url?foo=bar&apiKey=XXXXX&apiSecret=XXXXX&bar=baz');
 				});
 
 			});


### PR DESCRIPTION
This prevents any API keys and secrets from appearing in the logs when
somebody (or the GitHub webhook) uses query parameters. I've overridden
the default Morgan "url" token for this.