### PR TITLE
Cache repo endpoints for less time

### DIFF
--- a/lib/routes/v1/repos.js
+++ b/lib/routes/v1/repos.js
@@ -6,12 +6,14 @@ const semver = require('semver');
 
 module.exports = app => {
 
-	const cacheForSevenDays = cacheControl({
-		maxAge: '7d'
+	const cacheForFiveMinutes = cacheControl({
+		maxAge: '5 minutes',
+		staleWhileRevalidate: '7 days',
+		staleIfError: '7 days'
 	});
 
 	// List of all of the repositories
-	app.get('/v1/repos', requireAuth(requireAuth.READ), cacheForSevenDays, async (request, response, next) => {
+	app.get('/v1/repos', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
 		try {
 			response.send({
 				repos: (await app.model.Version.fetchLatest()).map(version => {
@@ -24,7 +26,7 @@ module.exports = app => {
 	});
 
 	// Single repository
-	app.get('/v1/repos/:repoId', requireAuth(requireAuth.READ), cacheForSevenDays, async (request, response, next) => {
+	app.get('/v1/repos/:repoId', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
 		try {
 			const repo = await app.model.Version.fetchLatestByRepoId(request.params.repoId);
 			if (!repo) {
@@ -39,7 +41,7 @@ module.exports = app => {
 	});
 
 	// List of all versions of a given repository
-	app.get('/v1/repos/:repoId/versions', requireAuth(requireAuth.READ), cacheForSevenDays, async (request, response, next) => {
+	app.get('/v1/repos/:repoId/versions', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
 		try {
 			const versions = await app.model.Version.fetchByRepoId(request.params.repoId);
 			if (!versions || versions.length === 0) {
@@ -52,7 +54,7 @@ module.exports = app => {
 	});
 
 	// Single version
-	app.get('/v1/repos/:repoId/versions/:versionId', requireAuth(requireAuth.READ), cacheForSevenDays, async (request, response, next) => {
+	app.get('/v1/repos/:repoId/versions/:versionId', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
 		try {
 			let version;
 


### PR DESCRIPTION
We now cache them for only 5 minutes, but provide longer stale while
revalidate and stale on error values.