### PR TITLE
Add endpoints to retrieve manifests and markdown

### DIFF
--- a/lib/routes/v1/repos.js
+++ b/lib/routes/v1/repos.js
@@ -56,23 +56,103 @@ module.exports = app => {
 	// Single version
 	app.get('/v1/repos/:repoId/versions/:versionId', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
 		try {
+			let redirect = false;
 			let version;
 
 			// Semver shortcut/redirect
 			if (semver.valid(request.params.versionId)) {
+				redirect = true;
 				version = await app.model.Version.fetchByRepoIdAndVersionNumber(request.params.repoId, request.params.versionId);
-				if (!version) {
-					return next();
-				}
-				response.redirect(307, `${request.basePath}v1/repos/${request.params.repoId}/versions/${version.get('id')}`);
 
 			// ID-based lookup
 			} else {
 				version = await app.model.Version.fetchByRepoIdAndVersionId(request.params.repoId, request.params.versionId);
-				if (!version) {
-					return next();
-				}
+			}
+			if (!version) {
+				return next();
+			}
+
+			// Redirect or respond
+			if (redirect) {
+				response.redirect(307, `${request.basePath}v1/repos/${request.params.repoId}/versions/${version.get('id')}`);
+			} else {
 				response.send({version});
+			}
+
+		} catch (error) {
+			next(error);
+		}
+	});
+
+	// Single version manifest
+	app.get('/v1/repos/:repoId/versions/:versionId/manifests/:manifestType', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
+		try {
+			let redirect = false;
+			let version;
+
+			// Semver shortcut/redirect
+			if (semver.valid(request.params.versionId)) {
+				redirect = true;
+				version = await app.model.Version.fetchByRepoIdAndVersionNumber(request.params.repoId, request.params.versionId);
+
+			// ID-based lookup
+			} else {
+				version = await app.model.Version.fetchByRepoIdAndVersionId(request.params.repoId, request.params.versionId);
+			}
+			if (!version) {
+				return next();
+			}
+
+			// Get the manifest
+			const manifests = version.get('manifests');
+			const manifest = manifests[request.params.manifestType];
+			if (!manifest) {
+				return next();
+			}
+
+			// Redirect or respond
+			if (redirect) {
+				response.redirect(307, `${request.basePath}v1/repos/${request.params.repoId}/versions/${version.get('id')}/manifests/${request.params.manifestType}`);
+			} else {
+				response.send(manifest);
+			}
+
+		} catch (error) {
+			next(error);
+		}
+	});
+
+	// Single version markdown
+	app.get('/v1/repos/:repoId/versions/:versionId/markdown/:markdownType', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
+		try {
+			let redirect = false;
+			let version;
+
+			// Semver shortcut/redirect
+			if (semver.valid(request.params.versionId)) {
+				redirect = true;
+				version = await app.model.Version.fetchByRepoIdAndVersionNumber(request.params.repoId, request.params.versionId);
+
+			// ID-based lookup
+			} else {
+				version = await app.model.Version.fetchByRepoIdAndVersionId(request.params.repoId, request.params.versionId);
+			}
+			if (!version) {
+				return next();
+			}
+
+			// Get the markdown
+			const markdownDocuments = version.get('markdown');
+			const markdownDocument = markdownDocuments[request.params.markdownType];
+			if (!markdownDocument) {
+				return next();
+			}
+
+			// Redirect or respond
+			if (redirect) {
+				response.redirect(307, `${request.basePath}v1/repos/${request.params.repoId}/versions/${version.get('id')}/markdown/${request.params.markdownType}`);
+			} else {
+				response.set('Content-Type', 'text/markdown').send(markdownDocument);
 			}
 
 		} catch (error) {

--- a/test/integration/routes/v1-repos-(id)-versions-(id)-manifests-(type).test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(id)-manifests-(type).test.js
@@ -1,0 +1,164 @@
+/* global agent, app */
+'use strict';
+
+const database = require('../helpers/database');
+const assert = require('proclaim');
+
+describe('GET /v1/repos/:repoId/versions/:versionId/manifests/:manifestType', () => {
+	let request;
+
+	beforeEach(async () => {
+		await database.seed(app, 'basic');
+		request = agent
+			.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/manifests/origami')
+			.set('X-Api-Key', 'mock-read-key')
+			.set('X-Api-Secret', 'mock-read-secret');
+	});
+
+	it('responds with a 200 status', () => {
+		return request.expect(200);
+	});
+
+	it('responds with JSON', () => {
+		return request.expect('Content-Type', /application\/json/);
+	});
+
+	describe('JSON response', () => {
+		let response;
+
+		beforeEach(async () => {
+			response = (await request.then()).body;
+		});
+
+		it('is the requested manifest', () => {
+			assert.isObject(response);
+			assert.strictEqual(response.name, 'o-mock-component');
+			assert.strictEqual(response.origamiType, 'module');
+		});
+
+	});
+
+	describe('when :repoId is not a valid repo ID', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/not-an-id/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/manifests/origami')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when :versionId is not a valid version ID', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/not-an-id/manifests/origami')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when :manifestType does not exist in the version manifests', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/manifests/not-a-manifest')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when :repoId and :versionID are mismatched', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/3731599a-f6a0-4856-8f28-9d10bc567d5b/manifests/origami')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when no API credentials are provided', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/manifests/origami');
+		});
+
+		it('responds with a 401 status', () => {
+			return request.expect(401);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/manifests/origami')
+				.set('X-Api-Key', 'mock-no-key')
+				.set('X-Api-Secret', 'mock-no-secret');
+		});
+
+		it('responds with a 403 status', () => {
+			return request.expect(403);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+});

--- a/test/integration/routes/v1-repos-(id)-versions-(id)-markdown-(type).test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(id)-markdown-(type).test.js
@@ -1,0 +1,163 @@
+/* global agent, app */
+'use strict';
+
+const database = require('../helpers/database');
+const assert = require('proclaim');
+
+describe('GET /v1/repos/:repoId/versions/:versionId/markdown/:markdownType', () => {
+	let request;
+
+	beforeEach(async () => {
+		await database.seed(app, 'basic');
+		request = agent
+			.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/markdown/readme')
+			.set('X-Api-Key', 'mock-read-key')
+			.set('X-Api-Secret', 'mock-read-secret');
+	});
+
+	it('responds with a 200 status', () => {
+		return request.expect(200);
+	});
+
+	it('responds with markdown', () => {
+		return request.expect('Content-Type', /text\/markdown/);
+	});
+
+	describe('markdown response', () => {
+		let response;
+
+		beforeEach(async () => {
+			response = (await request.then()).text;
+		});
+
+		it('is the requested markdown', () => {
+			assert.isString(response);
+			assert.strictEqual(response, 'mock-readme');
+		});
+
+	});
+
+	describe('when :repoId is not a valid repo ID', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/not-an-id/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/markdown/readme')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when :versionId is not a valid version ID', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/not-an-id/markdown/readme')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when :markdownType does not exist in the version markdown', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/markdown/not-a-markdown')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when :repoId and :versionID are mismatched', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/3731599a-f6a0-4856-8f28-9d10bc567d5b/markdown/readme')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when no API credentials are provided', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/markdown/readme');
+		});
+
+		it('responds with a 401 status', () => {
+			return request.expect(401);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/markdown/readme')
+				.set('X-Api-Key', 'mock-no-key')
+				.set('X-Api-Secret', 'mock-no-secret');
+		});
+
+		it('responds with a 403 status', () => {
+			return request.expect(403);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+});

--- a/test/integration/routes/v1-repos-(id)-versions-(number)-manifests-(type).test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(number)-manifests-(type).test.js
@@ -1,0 +1,152 @@
+/* global agent, app */
+'use strict';
+
+const database = require('../helpers/database');
+
+describe('GET /v1/repos/:repoId/versions/:versionNumber/manifests/:manifestType', () => {
+	let request;
+
+	beforeEach(async () => {
+		await database.seed(app, 'basic');
+		request = agent
+			.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/v1.0.0/manifests/origami')
+			.set('X-Api-Key', 'mock-read-key')
+			.set('X-Api-Secret', 'mock-read-secret');
+	});
+
+	it('responds with a 307 status', () => {
+		return request.expect(307);
+	});
+
+	it('responds with a Location header pointing to the ID-based endpoint', () => {
+		return request.expect('Location', '/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/manifests/origami');
+	});
+
+	it('responds with text', () => {
+		return request.expect('Content-Type', /text\/plain/);
+	});
+
+	describe('when :repoId is not a valid repo ID', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/not-an-id/versions/v1.0.0/manifests/origami')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when :versionNumber is not valid semver', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/not-semver/manifests/origami')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when :versionNumber is a valid semver number but the version does not exist', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/v123.456.789/manifests/origami')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when :manifestType does not exist in the version manifests', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/v1.0.0/manifests/not-a-manifest')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when no API credentials are provided', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/v1.0.0/manifests/origami');
+		});
+
+		it('responds with a 401 status', () => {
+			return request.expect(401);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/v1.0.0/manifests/origami')
+				.set('X-Api-Key', 'mock-no-key')
+				.set('X-Api-Secret', 'mock-no-secret');
+		});
+
+		it('responds with a 403 status', () => {
+			return request.expect(403);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+});

--- a/test/integration/routes/v1-repos-(id)-versions-(number)-markdown-(type).test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(number)-markdown-(type).test.js
@@ -1,0 +1,152 @@
+/* global agent, app */
+'use strict';
+
+const database = require('../helpers/database');
+
+describe('GET /v1/repos/:repoId/versions/:versionNumber/markdown/:markdownType', () => {
+	let request;
+
+	beforeEach(async () => {
+		await database.seed(app, 'basic');
+		request = agent
+			.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/v1.0.0/markdown/readme')
+			.set('X-Api-Key', 'mock-read-key')
+			.set('X-Api-Secret', 'mock-read-secret');
+	});
+
+	it('responds with a 307 status', () => {
+		return request.expect(307);
+	});
+
+	it('responds with a Location header pointing to the ID-based endpoint', () => {
+		return request.expect('Location', '/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/markdown/readme');
+	});
+
+	it('responds with text', () => {
+		return request.expect('Content-Type', /text\/plain/);
+	});
+
+	describe('when :repoId is not a valid repo ID', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/not-an-id/versions/v1.0.0/markdown/readme')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when :versionNumber is not valid semver', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/not-semver/markdown/readme')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when :versionNumber is a valid semver number but the version does not exist', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/v123.456.789/markdown/readme')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when :markdownType does not exist in the version markdown', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/v1.0.0/markdown/not-a-markdown')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when no API credentials are provided', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/v1.0.0/markdown/readme');
+		});
+
+		it('responds with a 401 status', () => {
+			return request.expect(401);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/v1.0.0/markdown/readme')
+				.set('X-Api-Key', 'mock-no-key')
+				.set('X-Api-Secret', 'mock-no-secret');
+		});
+
+		it('responds with a 403 status', () => {
+			return request.expect(403);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+	});
+
+});

--- a/test/integration/seed/basic/component.js
+++ b/test/integration/seed/basic/component.js
@@ -15,8 +15,16 @@ exports.seed = async database => {
 			support_channel: '#ft-origami',
 			tag: 'v1.0.0',
 			version: '1.0.0',
-			manifests: JSON.stringify({}),
-			markdown: JSON.stringify({})
+			manifests: JSON.stringify({
+				origami: {
+					name: 'o-mock-component',
+					origamiType: 'module',
+					isMockManifest: true
+				}
+			}),
+			markdown: JSON.stringify({
+				readme: 'mock-readme'
+			})
 		},
 		{
 			id: 'b2bdfae1-cc6f-4433-9a2f-8a4b762cda71',

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -462,6 +462,192 @@
 				</li>
 			</ul>
 
+
+			<h2 id="get-v1-repos-(id)-versions-(id)-manifests-(type)">Get a raw manifest file</h2>
+
+			<p>
+				Get a single manifest for an Origami repository and version by type. This endpoint
+				responds with the JSON contents of the requested manifest file. This endpoint requires
+				the <code>READ</code> permission.
+			</p>
+
+			<h3>Request</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Method</th>
+							<td>
+								<code>GET</code>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								Path
+							</th>
+							<td>
+								<code>/v1/repos/<var>:repo-id</var>/versions/<var>:version-id</var>/manifests/<var>:manifest-type</var></code><br/>
+								(where <var>:repo-id</var> is the unique identifier for a
+								<a href="#entity-repo">Repository</a>, <var>:version-id</var> is the
+								unique identifier for a <a href="#entity-version">Version</a> of it,
+								and <var>:manifest-type</var> is the type of manifest to retrieve –
+								one of <code>about</code>, <code>bower</code>, <code>imageset</code>,
+								<code>origami</code>, or <code>package</code>. The only manifest type
+								that is guaranteed to exist is <code>origami</code>)
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>X-Api-Key</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+									<dt>X-Api-Secret</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+								</dl>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Response</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Status</th>
+							<td>
+								<code>200</code> on success<br/>
+								<code>401</code> if authentication failed<br/>
+								<code>403</code> if authorization failed<br/>
+								<code>404</code> if a manifest matching <var>:repo-id</var>,
+								<var>:version-id</var>, and <var>:manifest-type</var> does not exist
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>Content-Type</dt>
+									<dd>
+										<code>application/json</code> on success<br/>
+										<code>text/html</code> on error
+									</dd>
+								</dl>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Body</th>
+							<td>
+								<pre><code class="json">{
+	// Manifest contents
+}</code></pre>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Example <code>curl</code> command:</h3>
+
+			<pre><code class="bash">curl \
+	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
+	https://origami-repo-data.ft.com/v1/repos/XXXXXX/versions/XXXXXX/manifests/origami</code></pre>
+
+
+			<h2 id="get-v1-repos-(id)-versions-(id)-markdown-(type)">Get a raw markdown document</h2>
+
+			<p>
+				Get a single markdown document for an Origami repository and version by type. This endpoint
+				responds with the markdown contents of the requested document. This endpoint requires
+				the <code>READ</code> permission.
+			</p>
+
+			<h3>Request</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Method</th>
+							<td>
+								<code>GET</code>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								Path
+							</th>
+							<td>
+								<code>/v1/repos/<var>:repo-id</var>/versions/<var>:version-id</var>/markdown/<var>:markdown-type</var></code><br/>
+								(where <var>:repo-id</var> is the unique identifier for a
+								<a href="#entity-repo">Repository</a>, <var>:version-id</var> is the
+								unique identifier for a <a href="#entity-version">Version</a> of it,
+								and <var>:markdown-type</var> is the name of the document to retrieve –
+								one of <code>designguidelines</code> or <code>readme</code>)
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>X-Api-Key</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+									<dt>X-Api-Secret</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+								</dl>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Response</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Status</th>
+							<td>
+								<code>200</code> on success<br/>
+								<code>401</code> if authentication failed<br/>
+								<code>403</code> if authorization failed<br/>
+								<code>404</code> if a markdown document matching <var>:repo-id</var>,
+								<var>:version-id</var>, and <var>:markdown-type</var> does not exist
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>Content-Type</dt>
+									<dd>
+										<code>text/markdown</code> on success<br/>
+										<code>text/html</code> on error
+									</dd>
+								</dl>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Body</th>
+							<td>
+								<pre><code>// Markdown contents</code></pre>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Example <code>curl</code> command:</h3>
+
+			<pre><code class="bash">curl \
+	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
+	https://origami-repo-data.ft.com/v1/repos/XXXXXX/versions/XXXXXX/markdown/readme</code></pre>
+
 		</div>
 
 	</div>


### PR DESCRIPTION
I've added two new endpoints which can be used to retrieve manifest
files and markdown documents for individual versions of a repository.
This part completes #43, which explains some of the decisions made here.

I'm aware that there's a lot of repetition in the controllers. Because
the integration tests have pretty good coverage I'd rather refactor the
controllers later and split into middleware, and would feel confident
doing so. Right now it'll just slow progress and I reckon would be
premature optimisation.

What's left to do is add aliases (outlined in the original issue)