### PR TITLE
Add resource URLs to repository and version output

### DIFF
--- a/models/version.js
+++ b/models/version.js
@@ -54,7 +54,8 @@ function initModel(app) {
 					channel: Version.parseSlackChannel(this.get('support_channel')),
 					isOrigami: this.get('support_is_origami')
 				},
-				lastUpdated: this.get('updated_at')
+				resources: this.get('resource_urls'),
+				lastIngested: this.get('updated_at')
 			};
 			// TODO more data should be exposed
 		},
@@ -65,6 +66,10 @@ function initModel(app) {
 
 			// Switch the IDs
 			repo.id = this.get('repo_id');
+
+			// Switch the resource URLs
+			repo.resources.self = repo.resources.repo;
+			delete repo.resources.repo;
 
 			return repo;
 		},
@@ -129,6 +134,24 @@ function initModel(app) {
 				return keywords
 					.filter(keyword => typeof keyword === 'string')
 					.map(keyword => keyword.trim().toLowerCase());
+			},
+
+			// Get helper resource URLs for the version
+			resource_urls() {
+				const urls = {
+					self: `/v1/repos/${this.get('repo_id')}/versions/${this.get('id')}`,
+					repo: `/v1/repos/${this.get('repo_id')}`,
+					versions: `/v1/repos/${this.get('repo_id')}/versions`,
+					manifests: {},
+					markdown: {}
+				};
+				for (const [name, value] of Object.entries(this.get('manifests') || {})) {
+					urls.manifests[name] = (value ? `${urls.self}/manifests/${name}` : null);
+				}
+				for (const [name, value] of Object.entries(this.get('markdown') || {})) {
+					urls.markdown[name] = (value ? `${urls.self}/markdown/${name}` : null);
+				}
+				return urls;
 			}
 
 		}

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -56,8 +56,21 @@
 		"isOrigami": true
 	},
 
+	// The paths for other API resources related to this repository.
+	// Each key will be either a string path or `null` if the resource does not exists
+	"resources": {
+		"self": "...",        // The canonical endpoint for this repository
+		"versions": "...",    // The endpoint which lists all versions for this repository
+		"manifests": {        // The endpoints which output named manifest files
+			"origami": "..."  // (other manifest files appear as key/value pairs)
+		},
+		"markdown": {         // The endpoints which output named markdown files
+			"readme": "..."   // (other manifest files appear as key/value pairs)
+		}
+	},
+
 	// When the repo was last ingested by {{origami.options.name}}
-	"lastUpdated": "2017-11-06T09:56:45.991Z"
+	"lastIngested": "2017-11-06T09:56:45.991Z"
 }</code></pre>
 
 			<h3 id="entity-version">Version Entity</h3>
@@ -75,8 +88,12 @@
 	// The semver version number that corresponds to this release
 	"version": "1.1.0",
 
-	// The commit hash that corresponds to this release
-	"commitHash": "XXXXXX"
+	// The paths for other API resources related to this version.
+	"resources": {
+		"self": "...",  // The canonical endpoint for this version
+		"repo": "...",  // The canonical endpoint for the repository this version belongs to
+		// The rest of these are the same as the resources for Repository entities
+	},
 }</code></pre>
 
 


### PR DESCRIPTION
Repository and Version entities now partially self-document by including
resource URLs in their output. This means that a client or dependent
application can know less about the way the service works, and also
eliminates the need for more aliases.

Example of the new resources property for a Version entity:

```diff
{
    "id": "bccf24f2-10f1-42d3-b442-6159013d7454",
    "name": "o-date",
    "url": "https://github.com/Financial-Times/o-date",
    "type": "module",
    "version": "2.9.0",

    ...

+    "resources": {
+        "self": "/v1/repos/b251334c-babb-59cc-a298-638bb540c7bf/versions/bccf24f2-10f1-42d3-b442-6159013d7454",
+        "repo": "/v1/repos/b251334c-babb-59cc-a298-638bb540c7bf",
+        "versions": "/v1/repos/b251334c-babb-59cc-a298-638bb540c7bf/versions",
+        "manifests": {
+            "about": null,
+            "bower": "/v1/repos/b251334c-babb-59cc-a298-638bb540c7bf/versions/bccf24f2-10f1-42d3-b442-6159013d7454/manifests/bower",
+            "imageSet": null,
+            "origami": "/v1/repos/b251334c-babb-59cc-a298-638bb540c7bf/versions/bccf24f2-10f1-42d3-b442-6159013d7454/manifests/origami",
+            "package": "/v1/repos/b251334c-babb-59cc-a298-638bb540c7bf/versions/bccf24f2-10f1-42d3-b442-6159013d7454/manifests/package"
+        },
+        "markdown": {
+            "readme": "/v1/repos/b251334c-babb-59cc-a298-638bb540c7bf/versions/bccf24f2-10f1-42d3-b442-6159013d7454/markdown/readme",
+            "designguidelines": null
+        }
+    },
    "lastIngested": "2017-12-11T09:31:32.048Z"
}
```