### PR TITLE
Handle space-separated keywords

### DIFF
--- a/models/version.js
+++ b/models/version.js
@@ -384,7 +384,7 @@ function initModel(app) {
 // Extract keywords from a manifest file
 function extractKeywords(manifest) {
 	if (typeof manifest.keywords === 'string') {
-		return manifest.keywords.split(',');
+		return manifest.keywords.trim().split(/[,\s]+/);
 	}
 	if (Array.isArray(manifest.keywords)) {
 		return manifest.keywords;


### PR DESCRIPTION
Quite a few components use spaces to separate keywords. This is
off-spec, but enough components do it that we should probably split on
space to that historical component versions have the correct keywords.

Resolves #47