### PR TITLE
Expose origamiCategory as subType

### DIFF
--- a/models/version.js
+++ b/models/version.js
@@ -45,6 +45,7 @@ function initModel(app) {
 				name: this.get('name'),
 				url: this.get('url'),
 				type: this.get('type'),
+				subType: this.get('sub_type'),
 				version: this.get('version'),
 				description: this.get('description'),
 				keywords: this.get('keywords'),
@@ -57,7 +58,6 @@ function initModel(app) {
 				resources: this.get('resource_urls'),
 				lastIngested: this.get('updated_at')
 			};
-			// TODO more data should be exposed
 		},
 
 		// Serialize the version as if it represented a repository
@@ -134,6 +134,15 @@ function initModel(app) {
 				return keywords
 					.filter(keyword => typeof keyword === 'string')
 					.map(keyword => keyword.trim().toLowerCase());
+			},
+
+			// Get the Origami sub-type (category) for the version
+			sub_type() {
+				const manifests = this.get('manifests') || {};
+				if (manifests.origami && manifests.origami.origamiCategory && typeof manifests.origami.origamiCategory === 'string') {
+					return manifests.origami.origamiCategory;
+				}
+				return null;
 			},
 
 			// Get helper resource URLs for the version

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -37,6 +37,10 @@
 	// The repo type, as outlined in the Origami Spec
 	"type": "module",
 
+	// The repo category, as outlined in the Origami Spec (under origamiCategory).
+	// Set to `null` when the repo type is not `module`
+	"subType": "component",
+
 	// The latest version of the repo to be published
 	"version": "1.1.0",
 


### PR DESCRIPTION
Sub-type makes a little more sense in the context of the repo data
output, and also keeps us decoupled from the exact naming in the Origami
JSON specification. This needs to be exposed so that the registry can
sort modules into separate navigation sections.