### PR TITLE
Add a supporting URLs property to repos/versions

### DIFF
--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -73,6 +73,14 @@
 		}
 	},
 
+	// Additional supporting URLs for this repository. Each key will be either a
+	// string URL or `null` if that supporting URL is not defined or does not apply
+	"supportingUrls": {
+		"ci": "...",      // A continuous integration dashboard for this repository
+		"issues": "...",  // The GitHub issues URL for this repository
+		"service": "..."  // The primary URL for the service, if this repository type is "service"
+	},
+
 	// When the repo was last ingested by {{origami.options.name}}
 	"lastIngested": "2017-11-06T09:56:45.991Z"
 }</code></pre>


### PR DESCRIPTION
This includes a couple of URLs that were missing from the output, and
are required to replicate the current registry pages.