### PR TITLE
Remove response envelopes

### DIFF
--- a/lib/routes/v1/keys.js
+++ b/lib/routes/v1/keys.js
@@ -25,10 +25,8 @@ module.exports = app => {
 			});
 			await key.save();
 			response.status(201).send({
-				credentials: {
-					id: key.get('id'),
-					secret: secret
-				}
+				id: key.get('id'),
+				secret: secret
 			});
 		} catch (error) {
 			if (error.name === 'ValidationError') {
@@ -47,9 +45,7 @@ module.exports = app => {
 	// List of all of the keys
 	app.get('/v1/keys', requireAuth(requireAuth.ADMIN), neverCache, async (request, response, next) => {
 		try {
-			response.send({
-				keys: await app.model.Key.fetchAll()
-			});
+			response.send(await app.model.Key.fetchAll());
 		} catch (error) {
 			next(error);
 		}
@@ -62,7 +58,7 @@ module.exports = app => {
 			if (!key) {
 				return next();
 			}
-			response.send({key});
+			response.send(key);
 		} catch (error) {
 			next(error);
 		}

--- a/lib/routes/v1/queue.js
+++ b/lib/routes/v1/queue.js
@@ -72,7 +72,7 @@ module.exports = app => {
 					tag: request.body.tag
 				});
 				await ingestion.save();
-				response.status(201).send({ingestion});
+				response.status(201).send(ingestion);
 
 			}
 
@@ -94,9 +94,7 @@ module.exports = app => {
 	// List of all of the items in the ingestion queue
 	app.get('/v1/queue', requireAuth(requireAuth.READ), neverCache, async (request, response, next) => {
 		try {
-			response.send({
-				queue: await app.model.Ingestion.fetchAll()
-			});
+			response.send(await app.model.Ingestion.fetchAll());
 		} catch (error) {
 			next(error);
 		}
@@ -109,7 +107,7 @@ module.exports = app => {
 			if (!ingestion) {
 				return next();
 			}
-			response.send({ingestion});
+			response.send(ingestion);
 		} catch (error) {
 			next(error);
 		}

--- a/lib/routes/v1/repos.js
+++ b/lib/routes/v1/repos.js
@@ -50,11 +50,10 @@ module.exports = app => {
 	// List of all of the repositories
 	app.get('/v1/repos', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
 		try {
-			response.send({
-				repos: (await app.model.Version.fetchLatest()).map(version => {
-					return version.serializeAsRepo();
-				})
+			const repos = (await app.model.Version.fetchLatest()).map(version => {
+				return version.serializeAsRepo();
 			});
+			response.send(repos);
 		} catch (error) {
 			next(error);
 		}
@@ -63,9 +62,7 @@ module.exports = app => {
 	// Single repository
 	app.get('/v1/repos/:repoId', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
 		try {
-			response.send({
-				repo: request.repo.serializeAsRepo()
-			});
+			response.send(request.repo.serializeAsRepo());
 		} catch (error) {
 			next(error);
 		}
@@ -74,9 +71,7 @@ module.exports = app => {
 	// List of all versions of a given repository
 	app.get('/v1/repos/:repoId/versions', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
 		try {
-			response.send({
-				versions: await app.model.Version.fetchByRepoId(request.repo.get('repo_id'))
-			});
+			response.send(await app.model.Version.fetchByRepoId(request.repo.get('repo_id')));
 		} catch (error) {
 			next(error);
 		}
@@ -85,9 +80,7 @@ module.exports = app => {
 	// Single version
 	app.get('/v1/repos/:repoId/versions/:versionId', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
 		try {
-			response.send({
-				version: request.version
-			});
+			response.send(request.version);
 		} catch (error) {
 			next(error);
 		}

--- a/test/integration/routes/v1-keys-(id).test.js
+++ b/test/integration/routes/v1-keys-(id).test.js
@@ -30,16 +30,10 @@ describe('GET /v1/keys/:keyId', () => {
 			response = (await request.then()).body;
 		});
 
-		it('has a `key` object property', () => {
-			assert.isObject(response.key);
-		});
-
-		it('includes the requested key with no secret', () => {
-
-			assert.isObject(response.key);
-			assert.strictEqual(response.key.id, 'mock-read-key');
-			assert.isUndefined(response.key.secret);
-
+		it('is the requested key with no secret', () => {
+			assert.isObject(response);
+			assert.strictEqual(response.id, 'mock-read-key');
+			assert.isUndefined(response.secret);
 		});
 
 	});

--- a/test/integration/routes/v1-keys.test.js
+++ b/test/integration/routes/v1-keys.test.js
@@ -31,29 +31,26 @@ describe('GET /v1/keys', () => {
 			response = (await request.then()).body;
 		});
 
-		it('has a `keys` array property', () => {
-			assert.isArray(response.keys);
-		});
+		it('is an array of each key in the database with no secrets output', () => {
+			assert.isArray(response);
+			assert.lengthEquals(response, 4);
 
-		it('includes each key in the database with no secrets output', () => {
-			assert.lengthEquals(response.keys, 4);
-
-			const key1 = response.keys[0];
+			const key1 = response[0];
 			assert.isObject(key1);
 			assert.strictEqual(key1.id, 'mock-admin-key');
 			assert.isUndefined(key1.secret);
 
-			const key2 = response.keys[1];
+			const key2 = response[1];
 			assert.isObject(key2);
 			assert.strictEqual(key2.id, 'mock-write-key');
 			assert.isUndefined(key2.secret);
 
-			const key3 = response.keys[2];
+			const key3 = response[2];
 			assert.isObject(key3);
 			assert.strictEqual(key3.id, 'mock-read-key');
 			assert.isUndefined(key3.secret);
 
-			const key4 = response.keys[3];
+			const key4 = response[3];
 			assert.isObject(key4);
 			assert.strictEqual(key4.id, 'mock-no-key');
 			assert.isUndefined(key4.secret);
@@ -153,17 +150,14 @@ describe('POST /v1/keys', () => {
 			response = (await request.then()).body;
 		});
 
-		it('has a `credentials` object property', () => {
-			assert.isObject(response.credentials);
-		});
-
-		it('includes the ID and secret of the new key', async () => {
+		it('is the ID and secret of the new key', async () => {
 			const keys = await app.database.knex.select('*').from('keys').where({
 				description: 'mock description'
 			});
-			assert.isString(response.credentials.id);
-			assert.isString(response.credentials.secret);
-			assert.isTrue(await bcrypt.compare(response.credentials.secret, keys[0].secret));
+			assert.isObject(response);
+			assert.isString(response.id);
+			assert.isString(response.secret);
+			assert.isTrue(await bcrypt.compare(response.secret, keys[0].secret));
 		});
 
 	});

--- a/test/integration/routes/v1-queue-(id).test.js
+++ b/test/integration/routes/v1-queue-(id).test.js
@@ -30,13 +30,9 @@ describe('GET /v1/queue/:ingestionId', () => {
 			response = (await request.then()).body;
 		});
 
-		it('has an `ingestion` object property', () => {
-			assert.isObject(response.ingestion);
-		});
-
-		it('includes the latest requested ingestion', () => {
-			assert.isObject(response.ingestion);
-			assert.strictEqual(response.ingestion.id, '5a070ea9-44f8-4312-8080-c4882d642ec4');
+		it('is the latest requested ingestion', () => {
+			assert.isObject(response);
+			assert.strictEqual(response.id, '5a070ea9-44f8-4312-8080-c4882d642ec4');
 		});
 
 	});

--- a/test/integration/routes/v1-queue.test.js
+++ b/test/integration/routes/v1-queue.test.js
@@ -30,18 +30,15 @@ describe('GET /v1/queue', () => {
 			response = (await request.then()).body;
 		});
 
-		it('has a `queue` array property', () => {
-			assert.isArray(response.queue);
-		});
+		it('is an array of each ingestion in the database', () => {
+			assert.isArray(response);
+			assert.lengthEquals(response, 5);
 
-		it('includes each ingestion in the database', () => {
-			assert.lengthEquals(response.queue, 5);
-
-			const ingestion1 = response.queue[0];
+			const ingestion1 = response[0];
 			assert.isObject(ingestion1);
 			assert.strictEqual(ingestion1.id, '5a070ea9-44f8-4312-8080-c4882d642ec4');
 
-			const ingestion2 = response.queue[1];
+			const ingestion2 = response[1];
 			assert.isObject(ingestion2);
 			assert.strictEqual(ingestion2.id, '988451cb-6d71-4a68-b435-3d5cf30b9614');
 
@@ -135,16 +132,13 @@ describe('POST /v1/queue', () => {
 			response = (await request.then()).body;
 		});
 
-		it('has a `ingestion` object property', () => {
-			assert.isObject(response.ingestion);
-		});
-
-		it('includes the ID of the new ingestion', async () => {
+		it('is the new ingestion', async () => {
 			const ingestions = await app.database.knex.select('*').from('ingestion_queue').where({
 				tag: 'v5.6.7'
 			});
-			assert.isString(response.ingestion.id);
-			assert.strictEqual(response.ingestion.id, ingestions[0].id);
+			assert.isObject(response);
+			assert.isString(response.id);
+			assert.strictEqual(response.id, ingestions[0].id);
 		});
 
 	});

--- a/test/integration/routes/v1-repos-(id)-versions-(id).test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(id).test.js
@@ -30,16 +30,10 @@ describe('GET /v1/repos/:repoId/versions/:versionId', () => {
 			response = (await request.then()).body;
 		});
 
-		it('has a `version` object property', () => {
-			assert.isObject(response.version);
-		});
-
-		it('includes the requested version', () => {
-
-			assert.isObject(response.version);
-			assert.strictEqual(response.version.id, '5bdc1cb5-19f1-4afe-883b-83c822fbbde0');
-			assert.strictEqual(response.version.name, 'o-mock-component');
-
+		it('is the requested version', () => {
+			assert.isObject(response);
+			assert.strictEqual(response.id, '5bdc1cb5-19f1-4afe-883b-83c822fbbde0');
+			assert.strictEqual(response.name, 'o-mock-component');
 		});
 
 	});

--- a/test/integration/routes/v1-repos-(id)-versions.test.js
+++ b/test/integration/routes/v1-repos-(id)-versions.test.js
@@ -30,26 +30,23 @@ describe('GET /v1/repos/:repoId/versions', () => {
 			response = (await request.then()).body;
 		});
 
-		it('has a `versions` array property', () => {
-			assert.isArray(response.versions);
-		});
+		it('is an array of all the versions for then given repository', () => {
+			assert.isArray(response);
+			assert.lengthEquals(response, 3);
 
-		it('includes the latest stored version for each repository in the database', () => {
-			assert.lengthEquals(response.versions, 3);
-
-			const version1 = response.versions[0];
+			const version1 = response[0];
 			assert.isObject(version1);
 			assert.strictEqual(version1.id, '9e4e450d-3b70-4672-b459-f297d434add6');
 			assert.strictEqual(version1.name, 'o-mock-component');
 			assert.strictEqual(version1.version, '2.0.0');
 
-			const version2 = response.versions[1];
+			const version2 = response[1];
 			assert.isObject(version2);
 			assert.strictEqual(version2.id, 'b2bdfae1-cc6f-4433-9a2f-8a4b762cda71');
 			assert.strictEqual(version2.name, 'o-mock-component');
 			assert.strictEqual(version2.version, '1.1.0');
 
-			const version3 = response.versions[2];
+			const version3 = response[2];
 			assert.isObject(version3);
 			assert.strictEqual(version3.id, '5bdc1cb5-19f1-4afe-883b-83c822fbbde0');
 			assert.strictEqual(version3.name, 'o-mock-component');

--- a/test/integration/routes/v1-repos-(id).test.js
+++ b/test/integration/routes/v1-repos-(id).test.js
@@ -30,16 +30,10 @@ describe('GET /v1/repos/:repoId', () => {
 			response = (await request.then()).body;
 		});
 
-		it('has a `repo` object property', () => {
-			assert.isObject(response.repo);
-		});
-
-		it('includes the latest version for the requested repository', () => {
-
-			assert.isObject(response.repo);
-			assert.strictEqual(response.repo.id, 'c990cb4b-c82b-5071-afb0-16149debc53d');
-			assert.strictEqual(response.repo.name, 'o-mock-component');
-
+		it('is the latest version for the requested repository', () => {
+			assert.isObject(response);
+			assert.strictEqual(response.id, 'c990cb4b-c82b-5071-afb0-16149debc53d');
+			assert.strictEqual(response.name, 'o-mock-component');
 		});
 
 	});

--- a/test/integration/routes/v1-repos.test.js
+++ b/test/integration/routes/v1-repos.test.js
@@ -30,19 +30,16 @@ describe('GET /v1/repos', () => {
 			response = (await request.then()).body;
 		});
 
-		it('has a `repos` array property', () => {
-			assert.isArray(response.repos);
-		});
+		it('is an array of the latest stored versions for each repository in the database', () => {
+			assert.isArray(response);
+			assert.lengthEquals(response, 2);
 
-		it('includes the latest stored version for each repository in the database', () => {
-			assert.lengthEquals(response.repos, 2);
-
-			const repo1 = response.repos[0];
+			const repo1 = response[0];
 			assert.isObject(repo1);
 			assert.strictEqual(repo1.id, '855d47ce-697e-51b9-9882-0c3c9044f0f5');
 			assert.strictEqual(repo1.name, 'mock-service');
 
-			const repo2 = response.repos[1];
+			const repo2 = response[1];
 			assert.isObject(repo2);
 			assert.strictEqual(repo2.id, 'c990cb4b-c82b-5071-afb0-16149debc53d');
 			assert.strictEqual(repo2.name, 'o-mock-component');

--- a/views/api/keys.html
+++ b/views/api/keys.html
@@ -126,14 +126,7 @@
 						<tr>
 							<th scope="row">Body</th>
 							<td>
-								<pre><code class="json">{
-	"keys": [
-		{
-			// Key entity
-		}
-	]
-}</code></pre>
-								<a href="#entity-key">(documentation on Key entities)</a>
+								Array of <a href="#entity-key">Key entities</a>
 							</td>
 						</tr>
 					</tbody>
@@ -218,12 +211,7 @@
 						<tr>
 							<th scope="row">Body</th>
 							<td>
-								<pre><code class="json">{
-	"key": {
-		// Key entity
-	}
-}</code></pre>
-								<a href="#entity-key">(documentation on Key entities)</a>
+								<a href="#entity-key">Key entity</a>
 							</td>
 						</tr>
 					</tbody>
@@ -328,12 +316,7 @@
 						<tr>
 							<th scope="row">Body</th>
 							<td>
-								<pre><code class="json">{
-	"credentials": {
-		// Credentials entity
-	}
-}</code></pre>
-								<a href="#entity-credentials">(documentation on Credentials entities)</a>
+								<a href="#entity-credentials">Credentials entity</a>
 							</td>
 						</tr>
 					</tbody>

--- a/views/api/queue.html
+++ b/views/api/queue.html
@@ -128,14 +128,7 @@
 						<tr>
 							<th scope="row">Body</th>
 							<td>
-								<pre><code class="json">{
-	"queue": [
-		{
-			// Ingestion entity
-		}
-	]
-}</code></pre>
-								<a href="#entity-ingestion">(documentation on Ingestion entities)</a>
+								Array of <a href="#entity-ingestion">Ingestion entities</a>
 							</td>
 						</tr>
 					</tbody>
@@ -220,12 +213,7 @@
 						<tr>
 							<th scope="row">Body</th>
 							<td>
-								<pre><code class="json">{
-	"ingestion": {
-		// Ingestion entity
-	}
-}</code></pre>
-								<a href="#entity-ingestion">(documentation on Ingestion entities)</a>
+								<a href="#entity-ingestion">Ingestion entity</a>
 							</td>
 						</tr>
 					</tbody>
@@ -329,12 +317,7 @@
 						<tr>
 							<th scope="row">Body</th>
 							<td>
-								<pre><code class="json">{
-	"ingestion": {
-		// Ingestion entity
-	}
-}</code></pre>
-								<a href="#entity-ingestion">(documentation on Ingestion entities)</a>
+								<a href="#entity-ingestion">Ingestion entity</a>
 							</td>
 						</tr>
 					</tbody>

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -177,14 +177,7 @@
 						<tr>
 							<th scope="row">Body</th>
 							<td>
-								<pre><code class="json">{
-	"repos": [
-		{
-			// Repository entity
-		}
-	]
-}</code></pre>
-								<a href="#entity-repo">(documentation on Repository entities)</a>
+								Array of <a href="#entity-repo">Repository entities</a>
 							</td>
 						</tr>
 					</tbody>
@@ -271,12 +264,7 @@
 						<tr>
 							<th scope="row">Body</th>
 							<td>
-								<pre><code class="json">{
-	"repo": {
-		// Repository entity
-	}
-}</code></pre>
-								<a href="#entity-repo">(documentation on Repository entities)</a>
+								<a href="#entity-repo">Repository entity</a>
 							</td>
 						</tr>
 					</tbody>
@@ -379,14 +367,7 @@
 						<tr>
 							<th scope="row">Body</th>
 							<td>
-								<pre><code class="json">{
-	"versions": [
-		{
-			// Version entity
-		}
-	]
-}</code></pre>
-								<a href="#entity-version">(documentation on Version entities)</a>
+								Array of <a href="#entity-version">Version entities</a>
 							</td>
 						</tr>
 					</tbody>
@@ -475,12 +456,7 @@
 						<tr>
 							<th scope="row">Body</th>
 							<td>
-								<pre><code class="json">{
-	"version": {
-		// Version entity
-	}
-}</code></pre>
-								<a href="#entity-version">(documentation on Version entities)</a>
+								<a href="#entity-version">Version entity</a>
 							</td>
 						</tr>
 					</tbody>
@@ -594,9 +570,7 @@
 						<tr>
 							<th scope="row">Body</th>
 							<td>
-								<pre><code class="json">{
-	// Manifest contents
-}</code></pre>
+								Manifest contents
 							</td>
 						</tr>
 					</tbody>
@@ -687,7 +661,7 @@
 						<tr>
 							<th scope="row">Body</th>
 							<td>
-								<pre><code>// Markdown contents</code></pre>
+								Markdown contents
 							</td>
 						</tr>
 					</tbody>


### PR DESCRIPTION
These make attempts at building a simple client a lot more complex than
is really necessary. Each response only contains one thing, and it seems
unnecessary to include a top level property wrapping that thing.

So now we've replaced this:

    { "repos": [{}, {}, {}] }

with this:

    [{}, {}, {}]