### PR TITLE
Switch to JSON for all service errors

### DIFF
--- a/lib/middleware/require-auth.js
+++ b/lib/middleware/require-auth.js
@@ -50,7 +50,7 @@ function requireAuth(level) {
 		if (!authorised) {
 			return next(httpError(
 				403,
-				'You are not authorised to perform this request'
+				'You are not authorized to perform this request'
 			));
 		}
 		request.authenticatedKey = key;

--- a/lib/routes/v1/keys.js
+++ b/lib/routes/v1/keys.js
@@ -30,12 +30,10 @@ module.exports = app => {
 			});
 		} catch (error) {
 			if (error.name === 'ValidationError') {
-				return response.status(400).render('error', {
-					title: 'Error 400',
-					error: {
-						isValidationError: true,
-						details: error.details
-					}
+				return response.status(400).send({
+					message: 'Validation failed',
+					validation: error.details.map(detail => detail.message),
+					status: 400
 				});
 			}
 			next(error);

--- a/lib/routes/v1/queue.js
+++ b/lib/routes/v1/queue.js
@@ -79,12 +79,10 @@ module.exports = app => {
 		} catch (error) {
 			if (error.name === 'ValidationError') {
 				const status = (error.isConflict ? 409 : 400);
-				return response.status(status).render('error', {
-					title: `Error ${status}`,
-					error: {
-						isValidationError: true,
-						details: error.details
-					}
+				return response.status(status).send({
+					message: 'Validation failed',
+					validation: error.details.map(detail => detail.message),
+					status: status
 				});
 			}
 			next(error);

--- a/lib/service.js
+++ b/lib/service.js
@@ -51,7 +51,9 @@ function service(options) {
 	app.use(origamiService.middleware.getBasePath());
 	mountRoutes(app);
 	app.use(origamiService.middleware.notFound());
-	app.use(origamiService.middleware.errorHandler());
+	app.use(origamiService.middleware.errorHandler({
+		outputJson: true
+	}));
 
 	app.database = bookshelf(knex({
 		client: 'pg',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,11 @@
   "requires": true,
   "dependencies": {
     "@financial-times/express-web-service": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/express-web-service/-/express-web-service-3.3.1.tgz",
-      "integrity": "sha1-+7OT80S2faHFtwZqXqwViXhag4o=",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/express-web-service/-/express-web-service-3.4.4.tgz",
+      "integrity": "sha512-ARz6eu3/OODyE92avlXXt9kvP960ytWKf0oWDYSgQXJ9ICg5Yi5frrKJFwqsab5EbYEzIMGtoIAyOzcSXkwHhA==",
       "requires": {
+        "@financial-times/origami-service-makefile": "6.1.0",
         "lodash": "4.17.4"
       }
     },
@@ -37,27 +38,27 @@
       }
     },
     "@financial-times/n-logger": {
-      "version": "5.5.7",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-5.5.7.tgz",
-      "integrity": "sha1-zDaEK8HQ8rPLEtFW6+Jo8gkGc6Q=",
+      "version": "5.5.10",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-5.5.10.tgz",
+      "integrity": "sha1-dhoqHScaEJl/aBeZkGT0CIUmpPg=",
       "requires": {
         "request": "2.83.0",
         "winston": "2.4.0"
       }
     },
     "@financial-times/origami-service": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/origami-service/-/origami-service-2.1.3.tgz",
-      "integrity": "sha1-AuvTKCOXY6SfyqCouQEA9VUFiB4=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/origami-service/-/origami-service-2.4.0.tgz",
+      "integrity": "sha512-uv+adQWfPpXruyAHacJugckGD2YybdV/I3UJwPDTPSDlwtGGtJ07mF2s8WMAZXa10YTzQiyUeMJ6J/gEyDkq6w==",
       "requires": {
-        "@financial-times/express-web-service": "3.3.1",
-        "express": "4.16.1",
+        "@financial-times/express-web-service": "3.4.4",
+        "express": "4.16.2",
         "express-handlebars": "3.0.0",
         "http-errors": "1.6.2",
         "lodash": "4.17.4",
         "morgan": "1.9.0",
         "ms": "2.0.0",
-        "next-metrics": "1.48.22",
+        "next-metrics": "1.48.29",
         "raven": "1.2.1",
         "request": "2.83.0",
         "request-promise-native": "1.0.5",
@@ -1226,9 +1227,9 @@
       }
     },
     "express": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.1.tgz",
-      "integrity": "sha512-STB7LZ4N0L+81FJHGla2oboUHTk4PaN1RsOkoRh9OSeEKylvF5hwKYVX1xCLFaCT7MD0BNG/gX2WFMLqY6EMBw==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
@@ -1269,8 +1270,8 @@
       "requires": {
         "glob": "6.0.4",
         "graceful-fs": "4.1.11",
-        "handlebars": "4.0.10",
-        "object.assign": "4.0.4",
+        "handlebars": "4.0.11",
+        "object.assign": "4.1.0",
         "promise": "7.3.1"
       }
     },
@@ -2723,9 +2724,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "requires": {
         "async": "1.5.2",
         "optimist": "0.6.1",
@@ -2760,6 +2761,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -3733,11 +3739,11 @@
       "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ="
     },
     "next-metrics": {
-      "version": "1.48.22",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-1.48.22.tgz",
-      "integrity": "sha1-Wa3yowDQ7O8WgG4KjH7MpO/4xtk=",
+      "version": "1.48.29",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-1.48.29.tgz",
+      "integrity": "sha1-g0zV0WYaacU+GSGyXNGg/smQ+hE=",
       "requires": {
-        "@financial-times/n-logger": "5.5.7",
+        "@financial-times/n-logger": "5.5.10",
         "debug": "1.0.5",
         "lodash": "2.4.2",
         "metrics": "0.1.14"
@@ -5782,12 +5788,13 @@
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
     "object.assign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "requires": {
         "define-properties": "1.1.2",
         "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
         "object-keys": "1.0.11"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@financial-times/health-check": "^1.2.1",
-    "@financial-times/origami-service": "^2.1.3",
+    "@financial-times/origami-service": "^2.4.0",
     "@financial-times/origami-service-makefile": "^6.1.0",
     "bcrypt": "^1.0.3",
     "body-parser": "^1.18.2",

--- a/test/integration/routes/404.test.js
+++ b/test/integration/routes/404.test.js
@@ -1,6 +1,7 @@
 /* global agent, app */
 'use strict';
 
+const assert = require('proclaim');
 const database = require('../helpers/database');
 
 describe('GET /404', () => {
@@ -15,8 +16,23 @@ describe('GET /404', () => {
 		return request.expect(404);
 	});
 
-	it('responds with HTML', () => {
-		return request.expect('Content-Type', /text\/html/);
+	it('responds with JSON', () => {
+		return request.expect('Content-Type', /application\/json/);
+	});
+
+	describe('JSON response', () => {
+		let response;
+
+		beforeEach(async () => {
+			response = (await request.then()).body;
+		});
+
+		it('contains the error details', () => {
+			assert.isObject(response);
+			assert.strictEqual(response.message, 'Not Found');
+			assert.strictEqual(response.status, 404);
+		});
+
 	});
 
 });

--- a/test/integration/routes/v1-keys-(id).test.js
+++ b/test/integration/routes/v1-keys-(id).test.js
@@ -53,8 +53,23 @@ describe('GET /v1/keys/:keyId', () => {
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -71,8 +86,23 @@ describe('GET /v1/keys/:keyId', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -92,8 +122,23 @@ describe('GET /v1/keys/:keyId', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});
@@ -136,8 +181,23 @@ describe('DELETE /v1/keys/:keyId', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});
@@ -157,8 +217,23 @@ describe('DELETE /v1/keys/:keyId', () => {
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -175,8 +250,23 @@ describe('DELETE /v1/keys/:keyId', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -196,8 +286,23 @@ describe('DELETE /v1/keys/:keyId', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});

--- a/test/integration/routes/v1-keys.test.js
+++ b/test/integration/routes/v1-keys.test.js
@@ -71,8 +71,23 @@ describe('GET /v1/keys', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -92,8 +107,23 @@ describe('GET /v1/keys', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});
@@ -182,19 +212,24 @@ describe('POST /v1/keys', () => {
 			return request.expect(400);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
 		});
 
-		describe('HTML response', () => {
+		describe('JSON response', () => {
 			let response;
 
 			beforeEach(async () => {
-				response = (await request.then()).text;
+				response = (await request.then()).body;
 			});
 
-			it('includes a descriptive error', () => {
-				assert.match(response, /description.+is required/);
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Validation failed');
+				assert.deepEqual(response.validation, [
+					'"description" is required'
+				]);
+				assert.strictEqual(response.status, 400);
 			});
 
 		});
@@ -257,21 +292,26 @@ describe('POST /v1/keys', () => {
 			return request.expect(400);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
 		});
 
-		describe('HTML response', () => {
+		describe('JSON response', () => {
 			let response;
 
 			beforeEach(async () => {
-				response = (await request.then()).text;
+				response = (await request.then()).body;
 			});
 
-			it('includes a descriptive error', () => {
-				assert.match(response, /read.+must be a boolean/);
-				assert.match(response, /write.+must be a boolean/);
-				assert.match(response, /admin.+must be a boolean/);
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Validation failed');
+				assert.deepEqual(response.validation, [
+					'"read" must be a boolean',
+					'"write" must be a boolean',
+					'"admin" must be a boolean'
+				]);
+				assert.strictEqual(response.status, 400);
 			});
 
 		});
@@ -290,8 +330,23 @@ describe('POST /v1/keys', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -311,8 +366,23 @@ describe('POST /v1/keys', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});

--- a/test/integration/routes/v1-queue-(id).test.js
+++ b/test/integration/routes/v1-queue-(id).test.js
@@ -52,8 +52,23 @@ describe('GET /v1/queue/:ingestionId', () => {
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -70,8 +85,23 @@ describe('GET /v1/queue/:ingestionId', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -91,8 +121,23 @@ describe('GET /v1/queue/:ingestionId', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});
@@ -135,8 +180,23 @@ describe('DELETE /v1/queue/:ingestionId', () => {
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -153,8 +213,23 @@ describe('DELETE /v1/queue/:ingestionId', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -174,8 +249,23 @@ describe('DELETE /v1/queue/:ingestionId', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});

--- a/test/integration/routes/v1-queue.test.js
+++ b/test/integration/routes/v1-queue.test.js
@@ -58,8 +58,23 @@ describe('GET /v1/queue', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -79,8 +94,23 @@ describe('GET /v1/queue', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});
@@ -162,19 +192,24 @@ describe('POST /v1/queue', () => {
 			return request.expect(409);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
 		});
 
-		describe('HTML response', () => {
+		describe('JSON response', () => {
 			let response;
 
 			beforeEach(async () => {
-				response = (await request.then()).text;
+				response = (await request.then()).body;
 			});
 
-			it('includes a descriptive error', () => {
-				assert.match(response, /already exists/);
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Validation failed');
+				assert.deepEqual(response.validation, [
+					'An ingestion or version with the given URL and tag already exists'
+				]);
+				assert.strictEqual(response.status, 409);
 			});
 
 		});
@@ -200,19 +235,24 @@ describe('POST /v1/queue', () => {
 			return request.expect(409);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
 		});
 
-		describe('HTML response', () => {
+		describe('JSON response', () => {
 			let response;
 
 			beforeEach(async () => {
-				response = (await request.then()).text;
+				response = (await request.then()).body;
 			});
 
-			it('includes a descriptive error', () => {
-				assert.match(response, /already exists/);
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Validation failed');
+				assert.deepEqual(response.validation, [
+					'An ingestion or version with the given URL and tag already exists'
+				]);
+				assert.strictEqual(response.status, 409);
 			});
 
 		});
@@ -235,20 +275,25 @@ describe('POST /v1/queue', () => {
 			return request.expect(400);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
 		});
 
-		describe('HTML response', () => {
+		describe('JSON response', () => {
 			let response;
 
 			beforeEach(async () => {
-				response = (await request.then()).text;
+				response = (await request.then()).body;
 			});
 
-			it('includes a descriptive error', () => {
-				assert.match(response, /url.+is required/);
-				assert.match(response, /tag.+is required/);
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Validation failed');
+				assert.deepEqual(response.validation, [
+					'"url" is required',
+					'"tag" is required'
+				]);
+				assert.strictEqual(response.status, 400);
 			});
 
 		});
@@ -267,8 +312,23 @@ describe('POST /v1/queue', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -288,8 +348,23 @@ describe('POST /v1/queue', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});
@@ -355,8 +430,23 @@ describe('POST /v1/queue (accepting a GitHub webhook)', () => {
 			return request.expect(400);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Only the "create" GitHub event is supported');
+				assert.strictEqual(response.status, 400);
+			});
+
 		});
 
 	});
@@ -434,8 +524,23 @@ describe('POST /v1/queue (accepting a GitHub webhook)', () => {
 			return request.expect(400);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'A repository URL is required');
+				assert.strictEqual(response.status, 400);
+			});
+
 		});
 
 	});
@@ -452,8 +557,23 @@ describe('POST /v1/queue (accepting a GitHub webhook)', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -479,8 +599,23 @@ describe('POST /v1/queue (accepting a GitHub webhook)', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});

--- a/test/integration/routes/v1-repos-(id)-versions-(id)-manifests-(type).test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(id)-manifests-(type).test.js
@@ -53,8 +53,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId/manifests/:manifestType', ()
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -74,8 +89,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId/manifests/:manifestType', ()
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -95,8 +125,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId/manifests/:manifestType', ()
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -116,8 +161,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId/manifests/:manifestType', ()
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -134,8 +194,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId/manifests/:manifestType', ()
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -155,8 +230,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId/manifests/:manifestType', ()
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});

--- a/test/integration/routes/v1-repos-(id)-versions-(id)-markdown-(type).test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(id)-markdown-(type).test.js
@@ -52,8 +52,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId/markdown/:markdownType', () 
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -73,8 +88,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId/markdown/:markdownType', () 
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -94,8 +124,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId/markdown/:markdownType', () 
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -115,8 +160,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId/markdown/:markdownType', () 
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -133,8 +193,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId/markdown/:markdownType', () 
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -154,8 +229,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId/markdown/:markdownType', () 
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});

--- a/test/integration/routes/v1-repos-(id)-versions-(id).test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(id).test.js
@@ -53,8 +53,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId', () => {
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -74,8 +89,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId', () => {
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -95,8 +125,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId', () => {
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -113,8 +158,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -134,8 +194,23 @@ describe('GET /v1/repos/:repoId/versions/:versionId', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});

--- a/test/integration/routes/v1-repos-(id)-versions.test.js
+++ b/test/integration/routes/v1-repos-(id)-versions.test.js
@@ -71,8 +71,23 @@ describe('GET /v1/repos/:repoId/versions', () => {
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -89,8 +104,23 @@ describe('GET /v1/repos/:repoId/versions', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -110,8 +140,23 @@ describe('GET /v1/repos/:repoId/versions', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});

--- a/test/integration/routes/v1-repos-(id).test.js
+++ b/test/integration/routes/v1-repos-(id).test.js
@@ -53,8 +53,23 @@ describe('GET /v1/repos/:repoId', () => {
 			return request.expect(404);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
 		});
 
 	});
@@ -71,8 +86,23 @@ describe('GET /v1/repos/:repoId', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -92,8 +122,23 @@ describe('GET /v1/repos/:repoId', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});

--- a/test/integration/routes/v1-repos.test.js
+++ b/test/integration/routes/v1-repos.test.js
@@ -60,8 +60,23 @@ describe('GET /v1/repos', () => {
 			return request.expect(401);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
 		});
 
 	});
@@ -81,8 +96,23 @@ describe('GET /v1/repos', () => {
 			return request.expect(403);
 		});
 
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
 		});
 
 	});

--- a/test/unit/lib/service.test.js
+++ b/test/unit/lib/service.test.js
@@ -295,7 +295,9 @@ describe('lib/service', () => {
 
 		it('creates and mounts error handling middleware', () => {
 			assert.calledOnce(origamiService.middleware.errorHandler);
-			assert.calledWithExactly(origamiService.middleware.errorHandler);
+			assert.calledWithExactly(origamiService.middleware.errorHandler, {
+				outputJson: true
+			});
 			assert.calledWith(origamiService.mockApp.use, origamiService.middleware.errorHandler.firstCall.returnValue);
 		});
 


### PR DESCRIPTION
This means that a client can more easily work out what's wrong, without
having to scan a load of boilerplate HTML.