### PR TITLE
Sort semantic versions correctly

### DIFF
--- a/data/migration/20180111170029_semver-sorting.js
+++ b/data/migration/20180111170029_semver-sorting.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const semver = require('semver');
+
+exports.up = async database => {
+
+	// Add split version fields to the versions table
+	await database.schema.table('versions', table => {
+		table.integer('version_major').notNullable().defaultTo(0);
+		table.integer('version_minor').notNullable().defaultTo(0);
+		table.integer('version_patch').notNullable().defaultTo(0);
+		table.string('version_prerelease').defaultTo(null);
+		table.index('version_major');
+		table.index('version_minor');
+		table.index('version_patch');
+		table.index('version_prerelease');
+	});
+
+	// Fill these fields for all existing versions
+	const versions = await database.select().from('versions');
+	for (const version of versions) {
+		const prerelease = semver.prerelease(version.version);
+		await database('versions').where('id', version.id).update({
+			version_major: semver.major(version.version),
+			version_minor: semver.minor(version.version),
+			version_patch: semver.patch(version.version),
+			version_prerelease: (prerelease ? prerelease.join('.') : prerelease)
+		});
+	}
+
+};
+
+exports.down = async database => {
+
+	// Remove the split version fields
+	await database.schema.table('versions', table => {
+		table.dropIndex('version_major');
+		table.dropIndex('version_minor');
+		table.dropIndex('version_patch');
+		table.dropIndex('version_prerelease');
+		table.dropColumn('version_major');
+		table.dropColumn('version_minor');
+		table.dropColumn('version_patch');
+		table.dropColumn('version_prerelease');
+	});
+
+};

--- a/data/seed/demo/example-component.js
+++ b/data/seed/demo/example-component.js
@@ -24,6 +24,10 @@ exports.seed = async database => {
 			support_channel: '#ft-origami',
 			tag: 'v1.0.0',
 			version: '1.0.0',
+			version_major: 1,
+			version_minor: 0,
+			version_patch: 0,
+			version_prerelease: null,
 			manifests: JSON.stringify({
 				about: null,
 				bower: {
@@ -60,6 +64,10 @@ exports.seed = async database => {
 			support_channel: '#ft-origami',
 			tag: 'v1.1.0',
 			version: '1.1.0',
+			version_major: 1,
+			version_minor: 1,
+			version_patch: 0,
+			version_prerelease: null,
 			manifests: JSON.stringify({
 				about: null,
 				bower: {
@@ -96,6 +104,10 @@ exports.seed = async database => {
 			support_channel: '#ft-origami',
 			tag: 'v2.0.0',
 			version: '2.0.0',
+			version_major: 2,
+			version_minor: 0,
+			version_patch: 0,
+			version_prerelease: null,
 			manifests: JSON.stringify({
 				about: null,
 				bower: {

--- a/data/seed/demo/example-node-module.js
+++ b/data/seed/demo/example-node-module.js
@@ -22,6 +22,10 @@ exports.seed = async database => {
 			support_channel: '#ft-origami',
 			tag: 'v1.0.0',
 			version: '1.0.0',
+			version_major: 1,
+			version_minor: 0,
+			version_patch: 0,
+			version_prerelease: null,
 			manifests: JSON.stringify({
 				about: null,
 				bower: null,
@@ -52,6 +56,10 @@ exports.seed = async database => {
 			support_channel: '#ft-origami',
 			tag: 'v1.1.0',
 			version: '1.1.0',
+			version_major: 1,
+			version_minor: 1,
+			version_patch: 0,
+			version_prerelease: null,
 			manifests: JSON.stringify({
 				about: null,
 				bower: null,

--- a/lib/routes/v1/repos.js
+++ b/lib/routes/v1/repos.js
@@ -50,7 +50,7 @@ module.exports = app => {
 	// List of all of the repositories
 	app.get('/v1/repos', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
 		try {
-			const repos = (await app.model.Version.fetchLatest()).map(version => {
+			const repos = (await app.model.Version.fetchRepos()).map(version => {
 				return version.serializeAsRepo();
 			});
 			response.send(repos);

--- a/test/integration/routes/v1-repos-(id)-versions.test.js
+++ b/test/integration/routes/v1-repos-(id)-versions.test.js
@@ -32,25 +32,31 @@ describe('GET /v1/repos/:repoId/versions', () => {
 
 		it('is an array of all the versions for then given repository', () => {
 			assert.isArray(response);
-			assert.lengthEquals(response, 3);
+			assert.lengthEquals(response, 4);
 
 			const version1 = response[0];
 			assert.isObject(version1);
-			assert.strictEqual(version1.id, '9e4e450d-3b70-4672-b459-f297d434add6');
+			assert.strictEqual(version1.id, 'dbd71199-c1ab-4482-9988-eee350b3bdca');
 			assert.strictEqual(version1.name, 'o-mock-component');
-			assert.strictEqual(version1.version, '2.0.0');
+			assert.strictEqual(version1.version, '3.0.0-beta.1');
 
 			const version2 = response[1];
 			assert.isObject(version2);
-			assert.strictEqual(version2.id, 'b2bdfae1-cc6f-4433-9a2f-8a4b762cda71');
+			assert.strictEqual(version2.id, '9e4e450d-3b70-4672-b459-f297d434add6');
 			assert.strictEqual(version2.name, 'o-mock-component');
-			assert.strictEqual(version2.version, '1.1.0');
+			assert.strictEqual(version2.version, '2.0.0');
 
 			const version3 = response[2];
 			assert.isObject(version3);
-			assert.strictEqual(version3.id, '5bdc1cb5-19f1-4afe-883b-83c822fbbde0');
+			assert.strictEqual(version3.id, 'b2bdfae1-cc6f-4433-9a2f-8a4b762cda71');
 			assert.strictEqual(version3.name, 'o-mock-component');
-			assert.strictEqual(version3.version, '1.0.0');
+			assert.strictEqual(version3.version, '1.1.0');
+
+			const version4 = response[3];
+			assert.isObject(version4);
+			assert.strictEqual(version4.id, '5bdc1cb5-19f1-4afe-883b-83c822fbbde0');
+			assert.strictEqual(version4.name, 'o-mock-component');
+			assert.strictEqual(version4.version, '1.0.0');
 
 		});
 

--- a/test/integration/routes/v1-repos.test.js
+++ b/test/integration/routes/v1-repos.test.js
@@ -30,7 +30,7 @@ describe('GET /v1/repos', () => {
 			response = (await request.then()).body;
 		});
 
-		it('is an array of the latest stored versions for each repository in the database', () => {
+		it('is an array of the latest stable versions for each repository in the database', () => {
 			assert.isArray(response);
 			assert.lengthEquals(response, 2);
 
@@ -38,11 +38,14 @@ describe('GET /v1/repos', () => {
 			assert.isObject(repo1);
 			assert.strictEqual(repo1.id, '855d47ce-697e-51b9-9882-0c3c9044f0f5');
 			assert.strictEqual(repo1.name, 'mock-service');
+			assert.strictEqual(repo1.version, '2.1.0');
 
 			const repo2 = response[1];
 			assert.isObject(repo2);
 			assert.strictEqual(repo2.id, 'c990cb4b-c82b-5071-afb0-16149debc53d');
 			assert.strictEqual(repo2.name, 'o-mock-component');
+			// This is the latest *stable* version, even though 3.0.0-beta.1 exists
+			assert.strictEqual(repo2.version, '2.0.0');
 
 		});
 

--- a/test/integration/seed/basic/component.js
+++ b/test/integration/seed/basic/component.js
@@ -15,6 +15,10 @@ exports.seed = async database => {
 			support_channel: '#ft-origami',
 			tag: 'v1.0.0',
 			version: '1.0.0',
+			version_major: 1,
+			version_minor: 0,
+			version_patch: 0,
+			version_prerelease: null,
 			manifests: JSON.stringify({
 				origami: {
 					name: 'o-mock-component',
@@ -38,6 +42,10 @@ exports.seed = async database => {
 			support_channel: '#ft-origami',
 			tag: 'v1.1.0',
 			version: '1.1.0',
+			version_major: 1,
+			version_minor: 1,
+			version_patch: 0,
+			version_prerelease: null,
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
 		},
@@ -53,6 +61,29 @@ exports.seed = async database => {
 			support_channel: '#ft-origami',
 			tag: 'v2.0.0',
 			version: '2.0.0',
+			version_major: 2,
+			version_minor: 0,
+			version_patch: 0,
+			version_prerelease: null,
+			manifests: JSON.stringify({}),
+			markdown: JSON.stringify({})
+		},
+		{
+			id: 'dbd71199-c1ab-4482-9988-eee350b3bdca',
+			repo_id: 'c990cb4b-c82b-5071-afb0-16149debc53d',
+			created_at: new Date('2017-01-04T00:00:00Z'),
+			updated_at: new Date('2017-01-04T00:00:00Z'),
+			name: 'o-mock-component',
+			type: 'module',
+			url: 'https://github.com/Financial-Times/o-mock-component',
+			support_email: 'origami.support@ft.com',
+			support_channel: '#ft-origami',
+			tag: 'v3.0.0-beta.1',
+			version: '3.0.0-beta.1',
+			version_major: 3,
+			version_minor: 0,
+			version_patch: 0,
+			version_prerelease: 'beta.1',
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
 		}

--- a/test/integration/seed/basic/service.js
+++ b/test/integration/seed/basic/service.js
@@ -15,6 +15,10 @@ exports.seed = async database => {
 			support_channel: '#ft-origami',
 			tag: 'v1.0.0',
 			version: '1.0.0',
+			version_major: 1,
+			version_minor: 0,
+			version_patch: 0,
+			version_prerelease: null,
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
 		},
@@ -30,6 +34,10 @@ exports.seed = async database => {
 			support_channel: '#ft-origami',
 			tag: 'v2.0.0',
 			version: '2.0.0',
+			version_major: 2,
+			version_minor: 0,
+			version_patch: 0,
+			version_prerelease: null,
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
 		},
@@ -45,6 +53,10 @@ exports.seed = async database => {
 			support_channel: '#ft-origami',
 			tag: 'v2.1.0',
 			version: '2.1.0',
+			version_major: 2,
+			version_minor: 1,
+			version_patch: 0,
+			version_prerelease: null,
 			manifests: JSON.stringify({}),
 			markdown: JSON.stringify({})
 		}

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -41,8 +41,11 @@
 	// Set to `null` when the repo type is not `module`
 	"subType": "component",
 
-	// The latest version of the repo to be published
+	// The latest version of the repo
 	"version": "1.1.0",
+
+	// The latest exact git tag of the repo
+	"version": "v1.1.0",
 
 	// A description and keywords for the repo, based on one of the JSON manifests in it
 	"description": "An example Node.js module",
@@ -57,7 +60,11 @@
 		"channel": "#ft-origami",
 
 		// An easy way to determine whether the Origami team maintains this repo
-		"isOrigami": true
+		"isOrigami": true,
+
+		// Whether the latest version of the repo is a prerelease
+		// (alpha, beta, or release-candidate)
+		"isPrerelease": false
 	},
 
 	// The paths for other API resources related to this repository.
@@ -100,12 +107,15 @@
 	// The semver version number that corresponds to this release
 	"version": "1.1.0",
 
-	// The paths for other API resources related to this version.
+	// The latest exact git tag of the version
+	"version": "v1.1.0",
+
+	// The paths for other API resources related to this version
 	"resources": {
 		"self": "...",  // The canonical endpoint for this version
 		"repo": "...",  // The canonical endpoint for the repository this version belongs to
 		// The rest of these are the same as the resources for Repository entities
-	},
+	}
 }</code></pre>
 
 


### PR DESCRIPTION
We have not been sorting semantic versions correctly, this work fixes
that. We now split the versions before storing each part in the database
so we can query against them and sort them appropriately.

There's a costly migration in here which I've tested against a copy of
the live database so we know that it runs fine.

I've also exposed our calculation of whether a version is a prerelease
in the output for repos and versions so that this logic doesn't have to
be duplicated in a consuming client.