### PR TITLE
Add Slack announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ We configure Origami Repo Data using environment variables. In development, conf
   * `RELEASE_LOG_API_KEY`: The change request API key to use when creating and closing release logs
   * `RELEASE_LOG_ENVIRONMENT`: The Salesforce environment to include in release logs. One of `Test` or `Production`
   * `SENTRY_DSN`: The Sentry URL to send error information to.
+  * `SLACK_ANNOUNCER_AUTH_TOKEN`: The Slack auth token to use when announcing new repo versions on Slack
+  * `SLACK_ANNOUNCER_CHANNEL_ID`: The Slack channel to announce new repo versions in (unique ID, not channel name)
 
 ### Required locally
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ const options = {
 	log: console,
 	name: 'Origami Repo Data',
 	workers: process.env.WEB_CONCURRENCY || 1,
-	enableSetupStep: !!process.env.ENABLE_SETUP_STEP
+	enableSetupStep: !!process.env.ENABLE_SETUP_STEP,
+	slackAnnouncerAuthToken: process.env.SLACK_ANNOUNCER_AUTH_TOKEN,
+	slackAnnouncerChannelId: process.env.SLACK_ANNOUNCER_CHANNEL_ID
 };
 
 throng({

--- a/lib/service.js
+++ b/lib/service.js
@@ -8,6 +8,7 @@ const knex = require('knex');
 const morgan = require('morgan');
 const origamiService = require('@financial-times/origami-service');
 const requireAll = require('require-all');
+const SlackAnnouncer = require('./slack-announcer');
 const url = require('url');
 
 module.exports = service;
@@ -64,6 +65,12 @@ function service(options) {
 	loadModels(app);
 
 	app.github = new GitHubClient(options.githubAuthToken);
+
+	app.slackAnnouncer = new SlackAnnouncer({
+		authToken: options.slackAnnouncerAuthToken,
+		channelId: options.slackAnnouncerChannelId,
+		log: app.origami.log
+	});
 
 	app.ingestionQueueProcessor = new IngestionQueueProcessor(app);
 	if (!options.disableIngestionQueue) {

--- a/lib/slack-announcer.js
+++ b/lib/slack-announcer.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const SlackWebApiClient = require('@slack/client').WebClient;
+
+// Announce new repo versions in Slack
+module.exports = class SlackAnnouncer {
+
+	constructor({authToken, channelId, log}) {
+		this.client = new SlackWebApiClient(authToken);
+		this.channelId = channelId;
+		this.log = log;
+	}
+
+	async announce(version) {
+
+		const name = version.get('name');
+		const versionNumber = version.get('version');
+		const supportStatus = version.get('support_status');
+		const isOrigami = version.get('support_is_origami');
+
+		if (supportStatus !== 'active' && supportStatus !== 'maintained') {
+			this.log.info(`Slack Announcer: type="ignore" repo="${name}" version="${versionNumber}" message="Support status is not active or maintained"`);
+			return;
+		}
+		if (!isOrigami) {
+			this.log.info(`Slack Announcer: type="ignore" repo="${name}" version="${versionNumber}" message="Repo is not maintained by Origami"`);
+			return;
+		}
+
+		const label = `${name} @ ${versionNumber}`;
+		const url = `https://origami-registry.ft.com/components/${name}@${versionNumber}`;
+
+		try {
+			await this.client.chat.postMessage(this.channelId, `New release: *<${url}|${label}>*`, {
+				as_user: true
+			});
+			this.log.info(`Slack Announcer: type="success" repo="${name}" version="${versionNumber}"`);
+		} catch (error) {
+			this.log.error(`Slack Announcer: type="error" repo="${name}" version="${versionNumber}" message="${error.message}"`);
+		}
+
+	}
+
+};

--- a/models/version.js
+++ b/models/version.js
@@ -412,7 +412,7 @@ function initModel(app) {
 					repo
 				});
 
-				// Create and return a new version
+				// Create the new version
 				const version = new Version({
 					name: repo,
 					type: origamiManifestNormalised.origamiType,
@@ -434,6 +434,11 @@ function initModel(app) {
 					}
 				});
 				await version.save();
+
+				// Announce the new version on Slack
+				await app.slackAnnouncer.announce(version);
+
+				// Return the new version
 				return version;
 
 			} catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,179 @@
       "resolved": "https://registry.npmjs.org/@financial-times/origami-service-makefile/-/origami-service-makefile-6.1.0.tgz",
       "integrity": "sha1-tLU9qjRqnF6RrX33DZx7DSF0zpU="
     },
+    "@slack/client": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@slack/client/-/client-3.15.0.tgz",
+      "integrity": "sha512-MIgf5s9PrcxFaPlkJ2cFOhrfh9/KOmUKK5GG/Eka1IJK7+oBCscJFnQ6FfYnZICwIQxWkkuiXmeWYWNevZhCLg==",
+      "requires": {
+        "async": "1.5.2",
+        "bluebird": "3.5.1",
+        "eventemitter3": "1.2.0",
+        "https-proxy-agent": "1.0.0",
+        "inherits": "2.0.3",
+        "lodash": "4.17.4",
+        "pkginfo": "0.4.1",
+        "request": "2.76.0",
+        "retry": "0.9.0",
+        "url-join": "0.0.1",
+        "winston": "2.4.0",
+        "ws": "1.1.5"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.11.0",
+            "is-my-json-valid": "2.17.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "requires": {
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
+        },
+        "request": {
+          "version": "2.76.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
+          "integrity": "sha1-vkRQWv73A2CgQ2lVEGvjlF2VVg4=",
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.4.3"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+        }
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1186,6 +1359,11 @@
         "stream-combiner": "0.0.4",
         "through": "2.3.8"
       }
+    },
+    "eventemitter3": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
     },
     "execa": {
       "version": "0.7.0",
@@ -2569,6 +2747,19 @@
         }
       }
     },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
     "generic-pool": {
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.5.4.tgz",
@@ -3038,6 +3229,17 @@
         "is-extglob": "1.0.0"
       }
     },
+    "is-my-json-valid": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -3097,6 +3299,11 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -3274,6 +3481,11 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -5868,6 +6080,11 @@
         }
       }
     },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -6042,17 +6259,20 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
       "requires": {
         "pinkie": "2.0.4"
       }
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
     },
     "pluralize": {
       "version": "7.0.0",
@@ -6432,6 +6652,11 @@
         "onetime": "2.0.1",
         "signal-exit": "3.0.2"
       }
+    },
+    "retry": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz",
+      "integrity": "sha1-b2l+UKDk3cjI9/tUeptg3q1DZ40="
     },
     "right-align": {
       "version": "0.1.3",
@@ -7037,6 +7262,11 @@
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
       "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
     },
+    "ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
     "undefsafe": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
@@ -7078,6 +7308,11 @@
         "semver-diff": "2.1.0",
         "xdg-basedir": "3.0.0"
       }
+    },
+    "url-join": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g="
     },
     "url-parse-lax": {
       "version": "1.0.0",
@@ -7307,6 +7542,15 @@
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
         "signal-exit": "3.0.2"
+      }
+    },
+    "ws": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+      "requires": {
+        "options": "0.0.6",
+        "ultron": "1.0.2"
       }
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@financial-times/health-check": "^1.2.1",
     "@financial-times/origami-service": "^2.4.0",
     "@financial-times/origami-service-makefile": "^6.1.0",
+    "@slack/client": "^3.15.0",
     "bcrypt": "^1.0.3",
     "body-parser": "^1.18.2",
     "bookshelf": "^0.10.4",

--- a/test/unit/lib/slack-announcer.test.js
+++ b/test/unit/lib/slack-announcer.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const assert = require('proclaim');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+describe.only('lib/slack-announcer', () => {
+	let log;
+	let SlackClient;
+	let SlackAnnouncer;
+
+	beforeEach(() => {
+
+		log = require('../mock/log.mock');
+
+		SlackClient = require('../mock/slack-client.mock');
+		mockery.registerMock('@slack/client', SlackClient);
+
+		SlackAnnouncer = require('../../../lib/slack-announcer');
+	});
+
+	it('exports a class constructor', () => {
+		assert.isFunction(SlackAnnouncer);
+		assert.throws(() => SlackAnnouncer(), /constructor slackannouncer/i); // eslint-disable-line new-cap
+	});
+
+	describe('new SlackAnnouncer(options)', () => {
+		let instance;
+		let options;
+
+		beforeEach(() => {
+			options = {
+				authToken: 'mock-auth-token',
+				channelId: 'mock-channel-id',
+				log: log
+			};
+			instance = new SlackAnnouncer(options);
+		});
+
+		it('has a `client` property set to a new Slack Web API client authenticated with `options.authToken`', () => {
+			assert.calledOnce(SlackClient.WebClient);
+			assert.calledWithNew(SlackClient.WebClient);
+			assert.calledWithExactly(SlackClient.WebClient, 'mock-auth-token');
+			assert.strictEqual(instance.client, SlackClient.mockWebClient);
+		});
+
+		it('has a `channelId` property set to `options.channelId`', () => {
+			assert.strictEqual(instance.channelId, 'mock-channel-id');
+		});
+
+		it('has a `log` property set to `options.log`', () => {
+			assert.strictEqual(instance.log, log);
+		});
+
+		describe('.announce(version)', () => {
+			let returnValue;
+			let version;
+
+			beforeEach(async () => {
+				version = {
+					get: sinon.stub()
+				};
+				version.get.withArgs('name').returns('mock-name');
+				version.get.withArgs('version').returns('mock-version');
+				version.get.withArgs('support_status').returns('active');
+				version.get.withArgs('support_is_origami').returns(true);
+				returnValue = await instance.announce(version);
+			});
+
+			it('posts an announcement to the Slack channel', () => {
+				assert.calledOnce(instance.client.chat.postMessage);
+				assert.calledWithExactly(
+					instance.client.chat.postMessage,
+					'mock-channel-id',
+					'New release: *<https://origami-registry.ft.com/components/mock-name@mock-version|mock-name @ mock-version>*',
+					{as_user: true}
+				);
+			});
+
+			it('returns nothing', () => {
+				assert.isUndefined(returnValue);
+			});
+
+			describe('when the version support status is not active or maintained', () => {
+
+				beforeEach(async () => {
+					instance.client.chat.postMessage.resetHistory();
+					version.get.withArgs('support_status').returns('deprecated');
+					returnValue = await instance.announce(version);
+				});
+
+				it('does not post an announcement to the Slack channel', () => {
+					assert.notCalled(instance.client.chat.postMessage);
+				});
+
+				it('returns nothing', () => {
+					assert.isUndefined(returnValue);
+				});
+
+			});
+
+			describe('when the version is not maintained by Origami', () => {
+
+				beforeEach(async () => {
+					instance.client.chat.postMessage.resetHistory();
+					version.get.withArgs('support_is_origami').returns(false);
+					returnValue = await instance.announce(version);
+				});
+
+				it('does not post an announcement to the Slack channel', () => {
+					assert.notCalled(instance.client.chat.postMessage);
+				});
+
+				it('returns nothing', () => {
+					assert.isUndefined(returnValue);
+				});
+
+			});
+
+			describe('when the message posting fails', () => {
+				let caughtError;
+				let slackError;
+
+				beforeEach(async () => {
+					slackError = new Error('mock-slack-error');
+					instance.client.chat.postMessage.rejects(slackError);
+					try {
+						returnValue = await instance.announce(version);
+					} catch (error) {
+						caughtError = error;
+					}
+				});
+
+				it('does not throw an error', () => {
+					assert.isUndefined(caughtError);
+				});
+
+				it('returns nothing', () => {
+					assert.isUndefined(returnValue);
+				});
+
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/mock/slack-announcer.mock.js
+++ b/test/unit/mock/slack-announcer.mock.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const SlackAnnouncer = module.exports = sinon.stub();
+
+const mockSlackAnnouncer = module.exports.mockSlackAnnouncer = {};
+
+SlackAnnouncer.returns(mockSlackAnnouncer);

--- a/test/unit/mock/slack-client.mock.js
+++ b/test/unit/mock/slack-client.mock.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const SlackClient = module.exports = {};
+
+const WebClient = SlackClient.WebClient = sinon.stub();
+
+const mockWebClient = module.exports.mockWebClient = {
+	chat: {
+		postMessage: sinon.stub().resolves()
+	}
+};
+
+WebClient.returns(mockWebClient);


### PR DESCRIPTION
This is mostly to test whether these are useful. We don't group them any
more, which may get a bit noisy.

I've added in logic to only announce Origami-maintained repos that are
either active or maintained, this should reduce the noise a bit.