### PR TITLE
Add a new demos endpoint

### DIFF
--- a/data/seed/demo/example-component.js
+++ b/data/seed/demo/example-component.js
@@ -10,6 +10,20 @@ exports.seed = async database => {
 		version3: '9e4e450d-3b70-4672-b459-f297d434add6',
 	};
 
+	// Use the same demos for each version
+	const demos = [
+		{
+			name: 'example1',
+			title: 'Example Demo 1',
+			description: 'This is an example demo'
+		},
+		{
+			name: 'example2',
+			title: 'Example Demo 2',
+			description: 'This is an example demo'
+		}
+	];
+
 	// Create a component repo which is maintained by Origami
 	await database('versions').insert([
 		{
@@ -42,7 +56,8 @@ exports.seed = async database => {
 					keywords: 'example, mock',
 					origamiVersion: 1,
 					support: 'https://github.com/Financial-Times/o-example-component/issues',
-					supportStatus: 'active'
+					supportStatus: 'active',
+					demos: demos
 				},
 				package: null
 			}),
@@ -82,7 +97,8 @@ exports.seed = async database => {
 					keywords: 'example, mock',
 					origamiVersion: 1,
 					support: 'https://github.com/Financial-Times/o-example-component/issues',
-					supportStatus: 'active'
+					supportStatus: 'active',
+					demos: demos
 				},
 				package: null
 			}),
@@ -122,7 +138,8 @@ exports.seed = async database => {
 					keywords: 'example, mock',
 					origamiVersion: 1,
 					support: 'https://github.com/Financial-Times/o-example-component/issues',
-					supportStatus: 'active'
+					supportStatus: 'active',
+					demos: demos
 				},
 				package: null
 			}),

--- a/lib/routes/v1/repos.js
+++ b/lib/routes/v1/repos.js
@@ -112,4 +112,17 @@ module.exports = app => {
 		}
 	});
 
+	// Single version demos
+	app.get('/v1/repos/:repoId/versions/:versionId/demos', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
+		try {
+			const demos = request.version.get('demos');
+			if (!demos) {
+				return next(httpError(404));
+			}
+			response.send(demos);
+		} catch (error) {
+			next(error);
+		}
+	});
+
 };

--- a/test/integration/routes/v1-repos-(id)-versions-(id)-demos.test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(id)-demos.test.js
@@ -1,0 +1,279 @@
+/* global agent, app */
+'use strict';
+
+const database = require('../helpers/database');
+const assert = require('proclaim');
+
+describe('GET /v1/repos/:repoId/versions/:versionId/demos', () => {
+	let request;
+
+	beforeEach(async () => {
+		await database.seed(app, 'basic');
+		request = agent
+			.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/demos')
+			.set('X-Api-Key', 'mock-read-key')
+			.set('X-Api-Secret', 'mock-read-secret');
+	});
+
+	it('responds with a 200 status', () => {
+		return request.expect(200);
+	});
+
+	it('responds with JSON', () => {
+		return request.expect('Content-Type', /application\/json/);
+	});
+
+	describe('JSON response', () => {
+		let response;
+
+		beforeEach(async () => {
+			response = (await request.then()).body;
+		});
+
+		it('is the version demos with some normalisation applied, and hidden/invalid demos removed', () => {
+			assert.isArray(response);
+			assert.lengthEquals(response, 3);
+
+			const demo1 = response[0];
+			assert.isObject(demo1);
+			assert.strictEqual(demo1.title, 'Example Demo 1');
+			assert.strictEqual(demo1.description, 'This is an example demo');
+			assert.isObject(demo1.supportingUrls);
+			assert.strictEqual(demo1.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v2/demos/o-mock-component@1.0.0/example1');
+			assert.deepEqual(demo1.display, {html: true});
+
+
+			const demo2 = response[1];
+			assert.isObject(demo2);
+			assert.strictEqual(demo2.title, 'Example Demo 2');
+			assert.isNull(demo2.description);
+			assert.isObject(demo2.supportingUrls);
+			assert.strictEqual(demo2.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v2/demos/o-mock-component@1.0.0/example2');
+			assert.deepEqual(demo2.display, {html: true});
+
+			const demo3 = response[2];
+			assert.isObject(demo3);
+			assert.strictEqual(demo3.title, 'Example No-HTML Demo');
+			assert.strictEqual(demo3.description, 'This is an example demo without HTMl to be displayed');
+			assert.isObject(demo3.supportingUrls);
+			assert.strictEqual(demo3.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v2/demos/o-mock-component@1.0.0/example-no-html');
+			assert.deepEqual(demo3.display, {html: false});
+
+		});
+
+	});
+
+	describe('when :repoId is not a valid repo ID', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/not-an-id/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/demos')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
+		});
+
+	});
+
+	describe('when :versionId is not a valid version ID', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/not-an-id/demos')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
+		});
+
+	});
+
+	describe('when the version does not have any demos', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/855d47ce-697e-51b9-9882-0c3c9044f0f5/versions/3731599a-f6a0-4856-8f28-9d10bc567d5b/demos')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
+		});
+
+	});
+
+	describe('when :repoId and :versionID are mismatched', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/3731599a-f6a0-4856-8f28-9d10bc567d5b/demos')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
+		});
+
+	});
+
+	describe('when no API credentials are provided', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/demos');
+		});
+
+		it('responds with a 401 status', () => {
+			return request.expect(401);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/demos')
+				.set('X-Api-Key', 'mock-no-key')
+				.set('X-Api-Secret', 'mock-no-secret');
+		});
+
+		it('responds with a 403 status', () => {
+			return request.expect(403);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
+		});
+
+	});
+
+});

--- a/test/integration/seed/basic/component.js
+++ b/test/integration/seed/basic/component.js
@@ -2,6 +2,47 @@
 
 // Create versions for a mock component
 exports.seed = async database => {
+
+	const manifests = {
+		origami: {
+			name: 'o-mock-component',
+			origamiType: 'module',
+			isMockManifest: true,
+			demos: [
+				{
+					name: 'example1',
+					title: 'Example Demo 1',
+					description: 'This is an example demo'
+				},
+				{
+					name: 'example2',
+					title: 'Example Demo 2',
+					description: ''
+				},
+				{
+					invalid: true
+				},
+				'invalid',
+				{
+					name: 'example-hidden',
+					title: 'Example Hidden Demo',
+					description: 'This is an example hidden demo',
+					hidden: true
+				},
+				{
+					name: 'example-no-html',
+					title: 'Example No-HTML Demo',
+					description: 'This is an example demo without HTMl to be displayed',
+					display_html: false
+				}
+			]
+		}
+	};
+
+	const markdown = {
+		readme: 'mock-readme'
+	};
+
 	await database('versions').insert([
 		{
 			id: '5bdc1cb5-19f1-4afe-883b-83c822fbbde0',
@@ -19,16 +60,8 @@ exports.seed = async database => {
 			version_minor: 0,
 			version_patch: 0,
 			version_prerelease: null,
-			manifests: JSON.stringify({
-				origami: {
-					name: 'o-mock-component',
-					origamiType: 'module',
-					isMockManifest: true
-				}
-			}),
-			markdown: JSON.stringify({
-				readme: 'mock-readme'
-			})
+			manifests: JSON.stringify(manifests),
+			markdown: JSON.stringify(markdown)
 		},
 		{
 			id: 'b2bdfae1-cc6f-4433-9a2f-8a4b762cda71',
@@ -46,8 +79,8 @@ exports.seed = async database => {
 			version_minor: 1,
 			version_patch: 0,
 			version_prerelease: null,
-			manifests: JSON.stringify({}),
-			markdown: JSON.stringify({})
+			manifests: JSON.stringify(manifests),
+			markdown: JSON.stringify(markdown)
 		},
 		{
 			id: '9e4e450d-3b70-4672-b459-f297d434add6',
@@ -65,8 +98,8 @@ exports.seed = async database => {
 			version_minor: 0,
 			version_patch: 0,
 			version_prerelease: null,
-			manifests: JSON.stringify({}),
-			markdown: JSON.stringify({})
+			manifests: JSON.stringify(manifests),
+			markdown: JSON.stringify(markdown)
 		},
 		{
 			id: 'dbd71199-c1ab-4482-9988-eee350b3bdca',
@@ -84,8 +117,8 @@ exports.seed = async database => {
 			version_minor: 0,
 			version_patch: 0,
 			version_prerelease: 'beta.1',
-			manifests: JSON.stringify({}),
-			markdown: JSON.stringify({})
+			manifests: JSON.stringify(manifests),
+			markdown: JSON.stringify(markdown)
 		}
 	]);
 };

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -118,6 +118,33 @@
 	}
 }</code></pre>
 
+			<h3 id="entity-demo">Demo Entity</h3>
+
+			<p>
+				Demo entities represent individual Origami demos for a <a href="#entity-version">Version</a>.
+				They differ from accessing the <code>origami.json</code> manifest demos in that they
+				are sanitized and normalised. As JSON they look like this:
+			</p>
+
+			<pre><code class="json">{
+	// The title of the demo
+	"title": "Example Demo",
+
+	// A short description of the demo, or `null` if one is not given
+	"description": "This is an example demo",
+
+	// Additional supporting URLs for this demo. Each key will be either a
+	// string URL or `null` if that supporting URL is not defined or does not apply
+	"supportingUrls": {
+		"live": "..."  // A live rendered version of this demo as an HTML page
+	},
+
+	// Flags indicating which parts of the demo should be displayed
+	"display": {
+		"html": true  // Whether the demo HTML should be considered useful and displayable
+	}
+}</code></pre>
+
 
 			<h2 id="get-v1-repos">Get all repositories</h2>
 
@@ -683,6 +710,95 @@
 			<pre><code class="bash">curl \
 	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
 	https://origami-repo-data.ft.com/v1/repos/XXXXXX/versions/XXXXXX/markdown/readme</code></pre>
+
+
+			<h2 id="get-v1-repos-(id)-versions-(id)-demos">Get demos for a version</h2>
+
+			<p>
+				Get a list of all demos for an Origami repository and version. This endpoint responds
+				with an array of <a href="#entity-demo">Demo entities</a> This endpoint requires the
+				<code>READ</code> permission.
+			</p>
+
+			<h3>Request</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Method</th>
+							<td>
+								<code>GET</code>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								Path
+							</th>
+							<td>
+								<code>/v1/repos/<var>:repo-id</var>/versions/<var>:version-id</var>/demos</code><br/>
+								(where <var>:repo-id</var> is the unique identifier for a
+								<a href="#entity-repo">Repository</a> and <var>:version-id</var> is the
+								unique identifier for a <a href="#entity-version">Version</a> of it)
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>X-Api-Key</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+									<dt>X-Api-Secret</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+								</dl>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Response</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Status</th>
+							<td>
+								<code>200</code> on success<br/>
+								<code>401</code> if authentication failed<br/>
+								<code>403</code> if authorization failed<br/>
+								<code>404</code> if there are no non-hidden demos for the
+								<var>:repo-id</var> and <var>:version-id</var>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>Content-Type</dt>
+									<dd>
+										<code>application/json</code> on success<br/>
+										<code>text/html</code> on error
+									</dd>
+								</dl>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Body</th>
+							<td>
+								Array of <a href="#entity-demo">Demo entities</a>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Example <code>curl</code> command:</h3>
+
+			<pre><code class="bash">curl \
+	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
+	https://origami-repo-data.ft.com/v1/repos/XXXXXX/versions/XXXXXX/demos</code></pre>
 
 		</div>
 


### PR DESCRIPTION
I've added a new endpoint which allows you to get the normalised demo
objects for a repo/version. This is required to reduce logic in the
registry, as safely sanitizing the demos takes enough for it to be a
bit painful.

The endpoint is:

```
GET /v1/repos/:repoId/versions/:versionId/demos
```