### PR TITLE
Add demo IDs to version output

### DIFF
--- a/models/version.js
+++ b/models/version.js
@@ -50,6 +50,7 @@ function initModel(app) {
 		serialize() {
 			return {
 				id: this.get('id'),
+				repo: this.get('repo_id'),
 				name: this.get('name'),
 				url: this.get('url'),
 				type: this.get('type'),
@@ -76,7 +77,8 @@ function initModel(app) {
 			const repo = this.serialize();
 
 			// Switch the IDs
-			repo.id = this.get('repo_id');
+			repo.id = repo.repo;
+			delete repo.repo;
 
 			// Switch the resource URLs
 			repo.resources.self = repo.resources.repo;

--- a/test/unit/lib/slack-announcer.test.js
+++ b/test/unit/lib/slack-announcer.test.js
@@ -4,7 +4,7 @@ const assert = require('proclaim');
 const mockery = require('mockery');
 const sinon = require('sinon');
 
-describe.only('lib/slack-announcer', () => {
+describe('lib/slack-announcer', () => {
 	let log;
 	let SlackClient;
 	let SlackAnnouncer;

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -104,6 +104,9 @@
 	// A unique identifier for the version, rather than the repo
 	"id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 
+	// A unique identifier for the repo this version belongs to
+	"repo": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+
 	// The semver version number that corresponds to this release
 	"version": "1.1.0",
 


### PR DESCRIPTION
We need this in the registry UI to reduce the number of API calls we
make. It makes sense to expose this anyway as otherwise the only way you
can get a repo ID is by extracting it from the URL.