### PR TITLE
Return demos which omit the title field.

### DIFF
--- a/models/version.js
+++ b/models/version.js
@@ -514,14 +514,16 @@ function initModel(app) {
 			if (!demo.name || typeof demo.name !== 'string') {
 				return null;
 			}
-			if (!demo.title || typeof demo.title !== 'string') {
+			// The title is required according to the spec but some components do not currently conform.
+			// http://origami.ft.com/docs/syntax/origamijson/#format
+			if (demo.title && typeof demo.title !== 'string') {
 				return null;
 			}
 			if (demo.description && typeof demo.description !== 'string') {
 				return null;
 			}
 			return {
-				title: demo.title,
+				title: demo.title || demo.name,
 				description: demo.description || null,
 				supportingUrls: {
 					live: `https://www.ft.com/__origami/service/build/v2/demos/${version.get('name')}@${version.get('version')}/${demo.name}`


### PR DESCRIPTION
http://origami.ft.com/docs/syntax/origamijson/#format

The `title` field is required in demo config according to the spec, however some components such as `o-table` omit the title field. This results in no demos being returned: https://origami-registry.ft.com/components/o-table

A better idea is to update the demos or remove the `title` requirement! 😄 Any thoughts on compiling a list of components with demos which miss the `title` field?