### PR TITLE
Add demo HTML URLs to the demos endpoint

### DIFF
--- a/models/version.js
+++ b/models/version.js
@@ -522,13 +522,16 @@ function initModel(app) {
 			if (demo.description && typeof demo.description !== 'string') {
 				return null;
 			}
+			const liveDemoUrl = `https://www.ft.com/__origami/service/build/v2/demos/${version.get('name')}@${version.get('version')}/${demo.name}`;
 			return {
 				title: demo.title || demo.name,
 				description: demo.description || null,
 				supportingUrls: {
-					live: `https://www.ft.com/__origami/service/build/v2/demos/${version.get('name')}@${version.get('version')}/${demo.name}`
+					live: liveDemoUrl,
+					html: (demo.display_html !== false ? `${liveDemoUrl}/html` : null)
 				},
 				display: {
+					live: true,
 					html: (demo.display_html !== false)
 				}
 			};

--- a/test/integration/routes/v1-repos-(id)-versions-(id)-demos.test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(id)-demos.test.js
@@ -40,8 +40,11 @@ describe('GET /v1/repos/:repoId/versions/:versionId/demos', () => {
 			assert.strictEqual(demo1.description, 'This is an example demo');
 			assert.isObject(demo1.supportingUrls);
 			assert.strictEqual(demo1.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v2/demos/o-mock-component@1.0.0/example1');
-			assert.deepEqual(demo1.display, {html: true});
-
+			assert.strictEqual(demo1.supportingUrls.html, 'https://www.ft.com/__origami/service/build/v2/demos/o-mock-component@1.0.0/example1/html');
+			assert.deepEqual(demo1.display, {
+				live: true,
+				html: true
+			});
 
 			const demo2 = response[1];
 			assert.isObject(demo2);
@@ -49,7 +52,11 @@ describe('GET /v1/repos/:repoId/versions/:versionId/demos', () => {
 			assert.isNull(demo2.description);
 			assert.isObject(demo2.supportingUrls);
 			assert.strictEqual(demo2.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v2/demos/o-mock-component@1.0.0/example2');
-			assert.deepEqual(demo2.display, {html: true});
+			assert.strictEqual(demo2.supportingUrls.html, 'https://www.ft.com/__origami/service/build/v2/demos/o-mock-component@1.0.0/example2/html');
+			assert.deepEqual(demo2.display, {
+				live: true,
+				html: true
+			});
 
 			const demo3 = response[2];
 			assert.isObject(demo3);
@@ -57,7 +64,11 @@ describe('GET /v1/repos/:repoId/versions/:versionId/demos', () => {
 			assert.strictEqual(demo3.description, 'This is an example demo without HTMl to be displayed');
 			assert.isObject(demo3.supportingUrls);
 			assert.strictEqual(demo3.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v2/demos/o-mock-component@1.0.0/example-no-html');
-			assert.deepEqual(demo3.display, {html: false});
+			assert.isNull(demo3.supportingUrls.html);
+			assert.deepEqual(demo3.display, {
+				live: true,
+				html: false
+			});
 
 		});
 

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -139,12 +139,14 @@
 	// Additional supporting URLs for this demo. Each key will be either a
 	// string URL or `null` if that supporting URL is not defined or does not apply
 	"supportingUrls": {
-		"live": "..."  // A live rendered version of this demo as an HTML page
+		"live": "...",  // A live rendered version of this demo as an HTML page
+		"html": "..."   // The HTML code required to reproduce this demo, with no boilerplate included
 	},
 
 	// Flags indicating which parts of the demo should be displayed
 	"display": {
-		"html": true  // Whether the demo HTML should be considered useful and displayable
+		"live": true,  // Whether the live demo should be considered useful and displayable
+		"html": true   // Whether the demo HTML should be considered useful and displayable
 	}
 }</code></pre>
 


### PR DESCRIPTION
This uses the new Build Service endpoint to reference the minimal HTML
required for demos. Registry UI can use this to display copyable HTML.