### PR TITLE
Add an endpoint for normalised image sets

### DIFF
--- a/lib/routes/v1/repos.js
+++ b/lib/routes/v1/repos.js
@@ -115,11 +115,24 @@ module.exports = app => {
 	// Single version demos
 	app.get('/v1/repos/:repoId/versions/:versionId/demos', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
 		try {
-			const demos = request.version.get('demos');
+			const demos = request.version.demos();
 			if (!demos) {
 				return next(httpError(404));
 			}
 			response.send(demos);
+		} catch (error) {
+			next(error);
+		}
+	});
+
+	// Single version images
+	app.get('/v1/repos/:repoId/versions/:versionId/images', requireAuth(requireAuth.READ), cacheForFiveMinutes, async (request, response, next) => {
+		try {
+			const images = request.version.images(request.query.sourceParam || undefined);
+			if (!images) {
+				return next(httpError(404));
+			}
+			response.send(images);
 		} catch (error) {
 			next(error);
 		}

--- a/test/integration/routes/v1-repos-(id)-versions-(id)-images.test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(id)-images.test.js
@@ -1,0 +1,312 @@
+/* global agent, app */
+'use strict';
+
+const database = require('../helpers/database');
+const assert = require('proclaim');
+
+describe('GET /v1/repos/:repoId/versions/:versionId/images', () => {
+	let request;
+
+	beforeEach(async () => {
+		await database.seed(app, 'basic');
+		request = agent
+			.get('/v1/repos/833bf423-4952-53e7-8fc0-e9e8554caf77/versions/ecd0f3c7-dac8-4354-95e0-cb9c0cd686ea/images')
+			.set('X-Api-Key', 'mock-read-key')
+			.set('X-Api-Secret', 'mock-read-secret');
+	});
+
+	it('responds with a 200 status', () => {
+		return request.expect(200);
+	});
+
+	it('responds with JSON', () => {
+		return request.expect('Content-Type', /application\/json/);
+	});
+
+	describe('JSON response', () => {
+		let response;
+
+		beforeEach(async () => {
+			response = (await request.then()).body;
+		});
+
+		it('is the version images with some normalisation applied', () => {
+			assert.isArray(response);
+			assert.lengthEquals(response, 2);
+
+			const image1 = response[0];
+			assert.isObject(image1);
+			assert.strictEqual(image1.title, 'example-image-1');
+			assert.isObject(image1.supportingUrls);
+			assert.strictEqual(image1.supportingUrls.full, 'https://www.ft.com/__origami/service/image/v2/images/raw/ftmock-v1:example-image-1?source=origami-repo-data');
+			assert.strictEqual(image1.supportingUrls.w200, 'https://www.ft.com/__origami/service/image/v2/images/raw/ftmock-v1:example-image-1?source=origami-repo-data&width=200');
+
+			const image2 = response[1];
+			assert.isObject(image2);
+			assert.strictEqual(image2.title, 'example-image-2');
+			assert.isObject(image2.supportingUrls);
+			assert.strictEqual(image2.supportingUrls.full, 'https://www.ft.com/__origami/service/image/v2/images/raw/ftmock-v1:example-image-2?source=origami-repo-data');
+			assert.strictEqual(image2.supportingUrls.w200, 'https://www.ft.com/__origami/service/image/v2/images/raw/ftmock-v1:example-image-2?source=origami-repo-data&width=200');
+
+		});
+
+	});
+
+	describe('when a `sourceParam` query parameter is provided', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/833bf423-4952-53e7-8fc0-e9e8554caf77/versions/ecd0f3c7-dac8-4354-95e0-cb9c0cd686ea/images?sourceParam=mock-source')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 200 status', () => {
+			return request.expect(200);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('is the version images with the given source param used in image URLs', () => {
+				assert.isArray(response);
+				assert.lengthEquals(response, 2);
+
+				const image1 = response[0];
+				assert.strictEqual(image1.supportingUrls.full, 'https://www.ft.com/__origami/service/image/v2/images/raw/ftmock-v1:example-image-1?source=mock-source');
+				assert.strictEqual(image1.supportingUrls.w200, 'https://www.ft.com/__origami/service/image/v2/images/raw/ftmock-v1:example-image-1?source=mock-source&width=200');
+
+				const image2 = response[1];
+				assert.strictEqual(image2.supportingUrls.full, 'https://www.ft.com/__origami/service/image/v2/images/raw/ftmock-v1:example-image-2?source=mock-source');
+				assert.strictEqual(image2.supportingUrls.w200, 'https://www.ft.com/__origami/service/image/v2/images/raw/ftmock-v1:example-image-2?source=mock-source&width=200');
+
+			});
+
+		});
+
+	});
+
+	describe('when :repoId is not a valid repo ID', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/not-an-id/versions/ecd0f3c7-dac8-4354-95e0-cb9c0cd686ea/images')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
+		});
+
+	});
+
+	describe('when :versionId is not a valid version ID', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/833bf423-4952-53e7-8fc0-e9e8554caf77/versions/not-an-id/images')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
+		});
+
+	});
+
+	describe('when the version does not have any images', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/c990cb4b-c82b-5071-afb0-16149debc53d/versions/5bdc1cb5-19f1-4afe-883b-83c822fbbde0/images')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
+		});
+
+	});
+
+	describe('when :repoId and :versionID are mismatched', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/833bf423-4952-53e7-8fc0-e9e8554caf77/versions/3731599a-f6a0-4856-8f28-9d10bc567d5b/images')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.strictEqual(response.message, 'Not Found');
+				assert.strictEqual(response.status, 404);
+			});
+
+		});
+
+	});
+
+	describe('when no API credentials are provided', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent.get('/v1/repos/833bf423-4952-53e7-8fc0-e9e8554caf77/versions/ecd0f3c7-dac8-4354-95e0-cb9c0cd686ea/images');
+		});
+
+		it('responds with a 401 status', () => {
+			return request.expect(401);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /api key\/secret .* required/i);
+				assert.strictEqual(response.status, 401);
+			});
+
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+		let request;
+
+		beforeEach(async () => {
+			await database.seed(app, 'basic');
+			request = agent
+				.get('/v1/repos/833bf423-4952-53e7-8fc0-e9e8554caf77/versions/ecd0f3c7-dac8-4354-95e0-cb9c0cd686ea/images')
+				.set('X-Api-Key', 'mock-no-key')
+				.set('X-Api-Secret', 'mock-no-secret');
+		});
+
+		it('responds with a 403 status', () => {
+			return request.expect(403);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains the error details', () => {
+				assert.isObject(response);
+				assert.match(response.message, /not authorized/i);
+				assert.strictEqual(response.status, 403);
+			});
+
+		});
+
+	});
+
+});

--- a/test/integration/routes/v1-repos.test.js
+++ b/test/integration/routes/v1-repos.test.js
@@ -32,7 +32,7 @@ describe('GET /v1/repos', () => {
 
 		it('is an array of the latest stable versions for each repository in the database', () => {
 			assert.isArray(response);
-			assert.lengthEquals(response, 2);
+			assert.lengthEquals(response, 3);
 
 			const repo1 = response[0];
 			assert.isObject(repo1);
@@ -46,6 +46,12 @@ describe('GET /v1/repos', () => {
 			assert.strictEqual(repo2.name, 'o-mock-component');
 			// This is the latest *stable* version, even though 3.0.0-beta.1 exists
 			assert.strictEqual(repo2.version, '2.0.0');
+
+			const repo3 = response[2];
+			assert.isObject(repo3);
+			assert.strictEqual(repo3.id, '833bf423-4952-53e7-8fc0-e9e8554caf77');
+			assert.strictEqual(repo3.name, 'o-mock-imageset');
+			assert.strictEqual(repo3.version, '1.0.0');
 
 		});
 

--- a/test/integration/seed/basic/imageset.js
+++ b/test/integration/seed/basic/imageset.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// Create versions for a mock component
+exports.seed = async database => {
+
+	const manifests = {
+		origami: {
+			name: 'o-mock-imageset',
+			origamiType: 'imageset',
+			isMockManifest: true
+		},
+		imageSet: {
+			scheme: 'ftmock',
+			images: [
+				{
+					name: 'example-image-1'
+				},
+				{
+					name: 'example-image-2'
+				}
+			]
+		}
+	};
+
+	const markdown = {
+		readme: 'mock-readme'
+	};
+
+	await database('versions').insert([
+		{
+			id: 'ecd0f3c7-dac8-4354-95e0-cb9c0cd686ea',
+			repo_id: '833bf423-4952-53e7-8fc0-e9e8554caf77',
+			created_at: new Date('2017-01-01T06:07:08Z'),
+			updated_at: new Date('2017-01-01T06:07:08Z'),
+			name: 'o-mock-imageset',
+			type: 'imageset',
+			url: 'https://github.com/Financial-Times/o-mock-imageset',
+			support_email: 'origami.support@ft.com',
+			support_channel: '#ft-origami',
+			tag: 'v1.0.0',
+			version: '1.0.0',
+			version_major: 1,
+			version_minor: 0,
+			version_patch: 0,
+			version_prerelease: null,
+			manifests: JSON.stringify(manifests),
+			markdown: JSON.stringify(markdown)
+		}
+	]);
+};

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -150,6 +150,25 @@
 	}
 }</code></pre>
 
+			<h3 id="entity-image">Image Entity</h3>
+
+			<p>
+				Image entities represent individual images in an Origami image set. They differ from
+				accessing the <code>imageset.json</code> manifest images in that they
+				are sanitized and normalised. As JSON they look like this:
+			</p>
+
+			<pre><code class="json">{
+	// The title of the image
+	"title": "example-image",
+
+	// Additional supporting URLs for this image. Each key will be a string image URL
+	"supportingUrls": {
+		"full": "...",  // An Image Service URL pointing to the full size image
+		"w200": "..."   // An Image Service URL pointing to a 200px wide copy of the image
+	}
+}</code></pre>
+
 
 			<h2 id="get-v1-repos">Get all repositories</h2>
 
@@ -721,7 +740,7 @@
 
 			<p>
 				Get a list of all demos for an Origami repository and version. This endpoint responds
-				with an array of <a href="#entity-demo">Demo entities</a> This endpoint requires the
+				with an array of <a href="#entity-demo">Demo entities</a>. This endpoint requires the
 				<code>READ</code> permission.
 			</p>
 
@@ -804,6 +823,106 @@
 			<pre><code class="bash">curl \
 	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
 	https://origami-repo-data.ft.com/v1/repos/XXXXXX/versions/XXXXXX/demos</code></pre>
+
+
+			<h2 id="get-v1-repos-(id)-versions-(id)-images">Get images for a version</h2>
+
+			<p>
+				Get a list of all images for an Origami repository and version, assuming that the
+				repository is an image set. This endpoint responds with an array of
+				<a href="#entity-image">Image entities</a>. This endpoint requires the
+				<code>READ</code> permission.
+			</p>
+
+			<h3>Request</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Method</th>
+							<td>
+								<code>GET</code>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								Path
+							</th>
+							<td>
+								<code>/v1/repos/<var>:repo-id</var>/versions/<var>:version-id</var>/images</code><br/>
+								(where <var>:repo-id</var> is the unique identifier for a
+								<a href="#entity-repo">Repository</a> and <var>:version-id</var> is the
+								unique identifier for a <a href="#entity-version">Version</a> of it)
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Querystring</th>
+							<td>
+								<dl>
+									<dt>sourceParam</dt>
+									<dd>Used to set the <code>source</code> querystring parameter for returned image URLs</dd>
+								</dl>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>X-Api-Key</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+									<dt>X-Api-Secret</dt>
+									<dd>See <a href="{{basePath}}v1/docs/api/authentication">authentication docs</a></dd>
+								</dl>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Response</h3>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tbody>
+						<tr>
+							<th scope="row">Status</th>
+							<td>
+								<code>200</code> on success<br/>
+								<code>401</code> if authentication failed<br/>
+								<code>403</code> if authorization failed<br/>
+								<code>404</code> if there are no images for the
+								<var>:repo-id</var> and <var>:version-id</var>, or the repository
+								is not an image set
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Headers</th>
+							<td>
+								<dl>
+									<dt>Content-Type</dt>
+									<dd>
+										<code>application/json</code> on success<br/>
+										<code>text/html</code> on error
+									</dd>
+								</dl>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Body</th>
+							<td>
+								Array of <a href="#entity-image">Image entities</a>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<h3>Example <code>curl</code> command:</h3>
+
+			<pre><code class="bash">curl \
+	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
+	https://origami-repo-data.ft.com/v1/repos/XXXXXX/versions/XXXXXX/images?sourceParam=curl</code></pre>
 
 		</div>
 


### PR DESCRIPTION
This adds a `/v1/repos/:repoId/versions/:versionId/images` endpoint
which can be used to retrieve a normalised list of images. These images
have Image Service URLs pre-baked in so that we can manage them in fewer
places and a consumer of the API doesn't have to know how the Image
Service works.

The URLs included are the full size one, and one with a width of 200px
(the width in the current registry)