### PR TITLE
Don't announce services on Slack

### DIFF
--- a/lib/slack-announcer.js
+++ b/lib/slack-announcer.js
@@ -14,6 +14,7 @@ module.exports = class SlackAnnouncer {
 	async announce(version) {
 
 		const name = version.get('name');
+		const type = version.get('type');
 		const versionNumber = version.get('version');
 		const supportStatus = version.get('support_status');
 		const isOrigami = version.get('support_is_origami');
@@ -24,6 +25,10 @@ module.exports = class SlackAnnouncer {
 		}
 		if (!isOrigami) {
 			this.log.info(`Slack Announcer: type="ignore" repo="${name}" version="${versionNumber}" message="Repo is not maintained by Origami"`);
+			return;
+		}
+		if (type === 'service') {
+			this.log.info(`Slack Announcer: type="ignore" repo="${name}" version="${versionNumber}" message="Repo is a service"`);
 			return;
 		}
 

--- a/test/unit/lib/slack-announcer.test.js
+++ b/test/unit/lib/slack-announcer.test.js
@@ -61,6 +61,7 @@ describe('lib/slack-announcer', () => {
 					get: sinon.stub()
 				};
 				version.get.withArgs('name').returns('mock-name');
+				version.get.withArgs('type').returns('module');
 				version.get.withArgs('version').returns('mock-version');
 				version.get.withArgs('support_status').returns('active');
 				version.get.withArgs('support_is_origami').returns(true);
@@ -104,6 +105,24 @@ describe('lib/slack-announcer', () => {
 				beforeEach(async () => {
 					instance.client.chat.postMessage.resetHistory();
 					version.get.withArgs('support_is_origami').returns(false);
+					returnValue = await instance.announce(version);
+				});
+
+				it('does not post an announcement to the Slack channel', () => {
+					assert.notCalled(instance.client.chat.postMessage);
+				});
+
+				it('returns nothing', () => {
+					assert.isUndefined(returnValue);
+				});
+
+			});
+
+			describe('when the version is a service', () => {
+
+				beforeEach(async () => {
+					instance.client.chat.postMessage.resetHistory();
+					version.get.withArgs('type').returns('service');
 					returnValue = await instance.announce(version);
 				});
 


### PR DESCRIPTION
Service version bumps are noisy and are only really useful for us
internally. Suppressing these from being announced.