### PR TITLE
Handle an empty string keywords correctly

### DIFF
--- a/models/version.js
+++ b/models/version.js
@@ -582,7 +582,7 @@ function initModel(app) {
 
 // Extract keywords from a manifest file
 function extractKeywords(manifest) {
-	if (typeof manifest.keywords === 'string') {
+	if (typeof manifest.keywords === 'string' && manifest.keywords.length) {
 		return manifest.keywords.trim().split(/[,\s]+/);
 	}
 	if (Array.isArray(manifest.keywords)) {

--- a/test/integration/routes/v1-repos-(id).test.js
+++ b/test/integration/routes/v1-repos-(id).test.js
@@ -34,6 +34,7 @@ describe('GET /v1/repos/:repoId', () => {
 			assert.isObject(response);
 			assert.strictEqual(response.id, 'c990cb4b-c82b-5071-afb0-16149debc53d');
 			assert.strictEqual(response.name, 'o-mock-component');
+			assert.deepEqual(response.keywords, []);
 		});
 
 	});

--- a/test/integration/seed/basic/component.js
+++ b/test/integration/seed/basic/component.js
@@ -7,6 +7,7 @@ exports.seed = async database => {
 		origami: {
 			name: 'o-mock-component',
 			origamiType: 'module',
+			keywords: "",
 			isMockManifest: true,
 			demos: [
 				{


### PR DESCRIPTION
We now return an empty array if keywords is an empty string

Fixes #74