### PR TITLE
Expose the image set scheme

### DIFF
--- a/models/version.js
+++ b/models/version.js
@@ -58,6 +58,7 @@ function initModel(app) {
 				subType: this.get('sub_type'),
 				version: this.get('version'),
 				versionTag: this.get('tag'),
+				imageSetScheme: this.get('imageset_scheme'),
 				description: this.get('description'),
 				keywords: this.get('keywords'),
 				languages: this.get('languages'),
@@ -149,6 +150,15 @@ function initModel(app) {
 			// Get whether the repo is a prerelease
 			support_is_prerelease() {
 				return (this.get('version_prerelease') !== null);
+			},
+
+			// Get the imageset scheme if the repo is an image-set
+			imageset_scheme() {
+				const manifests = this.get('manifests') || {};
+				if (manifests.imageSet && manifests.imageSet.scheme && typeof manifests.imageSet.scheme === 'string') {
+					return `${manifests.imageSet.scheme}-v${this.get('version_major')}`;
+				}
+				return null;
 			},
 
 			// Get a description of the version, falling back through different manifests

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -45,7 +45,10 @@
 	"version": "1.1.0",
 
 	// The latest exact git tag of the repo
-	"version": "v1.1.0",
+	"versionTag": "v1.1.0",
+
+	// The custom scheme of the imageset, if the repo represents an imageset
+	"imageSetScheme": "ftexample-v1",
 
 	// A description and keywords for the repo, based on one of the JSON manifests in it
 	"description": "An example Node.js module",


### PR DESCRIPTION
This exposes the image set scheme if a repo or version represents an
image set. We append the major version so that this doesn't need to be
done by a consuming client.