### PR TITLE
Support all Heroku Postgres database URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,23 @@ const throng = require('throng');
 
 dotenv.load();
 
+// Work out where the database URL is
+// (work with Heroku Postgres color named databases)
+let databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+	for (const [key, value] of Object.entries(process.env)) {
+		if (/^HEROKU_POSTGRESQL_[^_]+_URL$/.test(key)) {
+			databaseUrl = value;
+			break;
+		}
+	}
+}
+if (!databaseUrl) {
+	databaseUrl = 'postgres://localhost:5432/origami-repo-data';
+}
+
 const options = {
-	database: process.env.DATABASE_URL || 'postgres://localhost:5432/origami-repo-data',
+	database: databaseUrl,
 	githubAuthToken: process.env.GITHUB_AUTH_TOKEN,
 	log: console,
 	name: 'Origami Repo Data',


### PR DESCRIPTION
For larger tiers, and when multiple databases are present, Heroku names
its PostgreSQL databases after colours. These appear in environment
variables which we'll need to support. The new behaviour checks each of
the following:

  1. Check the `DATABASE_URL` environment variable
  2. Check all environment variables and use the first that matches a
     Heroku PostgreSQL database URL
  3. Default to localhost as before