### PR TITLE
Force SSL when using a Heroku PostgreSQL database

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,12 @@ let databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
 	for (const [key, value] of Object.entries(process.env)) {
 		if (/^HEROKU_POSTGRESQL_[^_]+_URL$/.test(key)) {
-			databaseUrl = value;
+			if (value.includes('ssl=true')) {
+				databaseUrl = value;
+			} else {
+				const joinCharacter = (value.includes('?') ? '&' : '?');
+				databaseUrl = `${value}${joinCharacter}ssl=true`;
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
We currently have to set this manually, and it's a bit brittle. Now if
we detect that we're using a Heroku PostgreSQL database we
automatically force SSL.