### PR TITLE
Prevent current nav items bleeding between users

### DIFF
--- a/lib/routes/v1/docs/api.js
+++ b/lib/routes/v1/docs/api.js
@@ -1,15 +1,10 @@
 'use strict';
 
 const cacheControl = require('@financial-times/origami-service').middleware.cacheControl;
-const navigation = require('../../../../data/navigation.json');
+const defaultNavigation = require('../../../../data/navigation.json');
+const clone = object => JSON.parse(JSON.stringify(object));
 
 module.exports = app => {
-	navigation.items.map(item => {
-		item.current = false;
-		if (item.hasChildren) {
-			item.children.map(child => child.current = false);
-		}
-	});
 
 	const cacheForSevenDays = cacheControl({
 		maxAge: '7d'
@@ -56,8 +51,17 @@ module.exports = app => {
 	];
 	endpoints.forEach(endpoint => {
 		app.get(`/v1/docs/api${endpoint.path}`, cacheForSevenDays, (request, response) => {
-			navigation.items[1].current = true;
-			navigation.items[1].children.find(child => child.current = (child.name === endpoint.name) ? true : false);
+
+			const navigation = clone(defaultNavigation);
+			navigation.items
+				.filter(item => item.href === 'v1/docs/api' && item.children)
+				.forEach(item => {
+					item.current = true;
+					item.children
+						.filter(child => child.href === `v1/docs/api${endpoint.path}`)
+						.forEach(child => child.current = true);
+				});
+
 			response.render(endpoint.view, {
 				title: `${endpoint.title}`,
 				navigation

--- a/lib/routes/v1/index.js
+++ b/lib/routes/v1/index.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const cacheControl = require('@financial-times/origami-service').middleware.cacheControl;
-const navigation = require('../../../data/navigation.json');
+const defaultNavigation = require('../../../data/navigation.json');
+const clone = object => JSON.parse(JSON.stringify(object));
 
 module.exports = app => {
-	navigation.items.map(item => item.current = false);
+
 	const neverCache = cacheControl({
 		maxAge: 0
 	});
@@ -16,7 +17,12 @@ module.exports = app => {
 			if (app.ft.options.enableSetupStep) {
 				setupCredentials = await setupService(app);
 			}
-			navigation.items[0].current = true;
+
+			const navigation = clone(defaultNavigation);
+			navigation.items
+				.filter(item => item.href === 'v1')
+				.forEach(item => item.current = true);
+
 			response.render('index', {
 				title: app.ft.options.name,
 				setupCredentials: setupCredentials,


### PR DESCRIPTION
We were using a single global object to represent the navigation, so
marking items as current marked them as current for every user of the
site. Oops.

This PR stops this from happening by cloning the navigation structure on
every request. I've also changed the way that we pick the top-level nav
item by testing against the `href` rather than accessing the first or
second item in the array.