### PR TITLE
Add a support email filter to `/v1/repos` endpoint

### DIFF
--- a/data/seed/demo/example-component-non-origami.js
+++ b/data/seed/demo/example-component-non-origami.js
@@ -1,0 +1,158 @@
+'use strict';
+
+exports.seed = async database => {
+
+	// UUIDs are static for the demo data so that we can share
+	// local links with eachother and predictably test
+	const ids = {
+		version1: '0BF9C54C-7E83-4049-9C6A-72C9A8134966',
+		version2: 'A0BD8634-EC99-4078-B4DD-F1A42AADBB2C',
+		version3: '573A990F-4412-4BEF-AB1B-4768461557D5',
+	};
+
+	// Use the same demos for each version
+	const demos = [
+		{
+			name: 'example1',
+			title: 'Example Demo 1',
+			description: 'This is an example demo'
+		},
+		{
+			name: 'example2',
+			title: 'Example Demo 2',
+			description: 'This is an example demo'
+		}
+	];
+
+	// Create a component repo which is maintained by Origami
+	await database('versions').insert([
+		{
+			id: ids.version1,
+			repo_id: '423c7b28-b294-56f9-a7ea-c6ad675e0c04',
+			created_at: new Date(Date.now() - 20000),
+			updated_at: new Date(Date.now() - 20000),
+			name: 'o-example-component-non-origami',
+			type: 'module',
+			url: 'https://github.com/Financial-Times/o-example-component-non-origami',
+			support_email: 'next.developers@ft.com',
+			support_channel: '#ft-next-dev',
+			tag: 'v1.0.0',
+			version: '1.0.0',
+			version_major: 1,
+			version_minor: 0,
+			version_patch: 0,
+			version_prerelease: null,
+			manifests: JSON.stringify({
+				about: null,
+				bower: {
+					name: 'o-example-component-non-origami',
+					dependencies: {}
+				},
+				imageSet: null,
+				origami: {
+					description: 'An example Origami component not supported by the team',
+					origamiType: 'module',
+					origamiCategory: 'components',
+					brands: [
+						'master',
+						'internal'
+					],
+					keywords: 'example, mock',
+					origamiVersion: 1,
+					support: 'https://github.com/Financial-Times/o-example-component-non-origami/issues',
+					supportStatus: 'active',
+					demos: demos
+				},
+				package: null
+			}),
+			markdown: JSON.stringify({
+				designGuidelines: 'TODO add mock design guidelines',
+				migrationGuide: null,
+				readme: 'TODO add mock README'
+			})
+		},
+		{
+			id: ids.version2,
+			repo_id: '423c7b28-b294-56f9-a7ea-c6ad675e0c04',
+			created_at: new Date(Date.now() - 7500),
+			updated_at: new Date(Date.now() - 7500),
+			name: 'o-example-component-non-origami',
+			type: 'module',
+			url: 'https://github.com/Financial-Times/o-example-component-non-origami',
+			support_email: 'next.developers@ft.com',
+			support_channel: '#ft-next-dev',
+			tag: 'v1.0.1',
+			version: '1.0.1',
+			version_major: 1,
+			version_minor: 0,
+			version_patch: 1,
+			version_prerelease: null,
+			manifests: JSON.stringify({
+				about: null,
+				bower: {
+					name: 'o-example-component-non-origami',
+					dependencies: {}
+				},
+				imageSet: null,
+				origami: {
+					description: 'An example Origami component not supported by the team',
+					origamiType: 'module',
+					origamiCategory: 'components',
+					keywords: 'example, mock',
+					origamiVersion: 1,
+					support: 'https://github.com/Financial-Times/o-example-component-non-origami/issues',
+					supportStatus: 'active',
+					demos: demos
+				},
+				package: null
+			}),
+			markdown: JSON.stringify({
+				designGuidelines: 'TODO add mock design guidelines',
+				migrationGuide: null,
+				readme: 'TODO add mock README'
+			})
+		},
+		{
+			id: ids.version3,
+			repo_id: '423c7b28-b294-56f9-a7ea-c6ad675e0c04',
+			created_at: new Date(Date.now() - 500),
+			updated_at: new Date(Date.now() - 500),
+			name: 'o-example-component-non-origami',
+			type: 'module',
+			url: 'https://github.com/Financial-Times/o-example-component-non-origami',
+			support_email: 'next.developers@ft.com',
+			support_channel: '#ft-next-dev',
+			tag: 'v2.0.0',
+			version: '2.0.0',
+			version_major: 2,
+			version_minor: 0,
+			version_patch: 0,
+			version_prerelease: null,
+			manifests: JSON.stringify({
+				about: null,
+				bower: {
+					name: 'o-example-component-non-origami',
+					dependencies: {}
+				},
+				imageSet: null,
+				origami: {
+					description: 'An example Origami component not supported by the team',
+					origamiType: 'module',
+					origamiCategory: 'components',
+					keywords: 'example, mock',
+					origamiVersion: 1,
+					support: 'https://github.com/Financial-Times/o-example-component-non-origami/issues',
+					supportStatus: 'active',
+					demos: demos
+				},
+				package: null
+			}),
+			markdown: JSON.stringify({
+				designGuidelines: 'TODO add mock design guidelines',
+				migrationGuide: null,
+				readme: 'TODO add mock README'
+			})
+		}
+	]);
+
+};

--- a/lib/routes/v1/repos.js
+++ b/lib/routes/v1/repos.js
@@ -71,12 +71,14 @@ module.exports = app => {
 			brand: request.validQuery.brand,
 			type: request.query.type,
 			status: request.query.status,
+			supportEmail: request.query.supportEmail,
 			search: request.query.q
 		};
 		const hasFilters = (
 			filters.brand ||
 			filters.type ||
 			filters.status ||
+			filters.supportEmail ||
 			filters.search
 		);
 

--- a/models/version.js
+++ b/models/version.js
@@ -442,6 +442,7 @@ function initModel(app) {
 			return (await this.fetchRepos())
 				.filter(propertyFilter('brands', filters.brand))
 				.filter(propertyFilter('type', filters.type))
+				.filter(propertyFilter('support_email', filters.supportEmail))
 				.filter(propertyFilter('support_status', filters.status))
 				.filter(repo => {
 					repo.searchScore = 0;

--- a/test/integration/routes/v1-repos.test.js
+++ b/test/integration/routes/v1-repos.test.js
@@ -164,7 +164,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains only actively supported repos', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 4);
+				assert.lengthEquals(response, 5);
 				for (const repo of response) {
 					assert.strictEqual(repo.support.status, 'active');
 				}
@@ -272,9 +272,117 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains only module components', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 6);
+				assert.lengthEquals(response, 7);
 				for (const repo of response) {
 					assert.strictEqual(repo.type, 'module');
+				}
+			});
+
+		});
+
+	});
+
+	describe('supportEmail=origami.support@ft.com', () => {
+
+		beforeEach(async () => {
+			request = agent
+				.get('/v1/repos?supportEmail=origami.support@ft.com')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 200 status', () => {
+			return request.expect(200);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains only components with the expected support email', () => {
+				assert.isArray(response);
+				assert.lengthEquals(response, 9);
+				for (const repo of response) {
+					assert.strictEqual(repo.support.email, 'origami.support@ft.com');
+				}
+			});
+
+		});
+
+	});
+
+	describe('supportEmail=next.developers@ft.com', () => {
+
+		beforeEach(async () => {
+			request = agent
+				.get('/v1/repos?supportEmail=next.developers@ft.com')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 200 status', () => {
+			return request.expect(200);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains only components with the expected support email', () => {
+				assert.isArray(response);
+				assert.lengthEquals(response, 1);
+				for (const repo of response) {
+					assert.strictEqual(repo.support.email, 'next.developers@ft.com');
+				}
+			});
+
+		});
+
+	});
+
+	describe('supportEmail=origami.support@ft.com,next.developers@ft.com', () => {
+
+		beforeEach(async () => {
+			request = agent
+				.get('/v1/repos?supportEmail=origami.support@ft.com,next.developers@ft.com')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 200 status', () => {
+			return request.expect(200);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains components with either support email', () => {
+				assert.isArray(response);
+				assert.lengthEquals(response, 10);
+				for (const repo of response) {
+					assert.include(['origami.support@ft.com', 'next.developers@ft.com'], repo.support.email);
 				}
 			});
 
@@ -344,7 +452,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains both module and service components', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 7);
+				assert.lengthEquals(response, 8);
 				for (const repo of response) {
 					assert.include(['module', 'service'], repo.type);
 				}
@@ -452,7 +560,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains only components which have not been branded', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 5);
+				assert.lengthEquals(response, 6);
 				for (const repo of response) {
 					if (repo.type === 'module') {
 						assert.deepEqual(repo.brands, []);

--- a/test/integration/seed/search/repos.js
+++ b/test/integration/seed/search/repos.js
@@ -13,8 +13,8 @@ exports.seed = async database => {
 			created_at: new Date('2018-01-01T00:00:00Z'),
 			updated_at: new Date('2018-01-01T00:00:00Z'),
 			url: `https://github.com/Financial-Times/${data.name}`,
-			support_email: 'origami.support@ft.com',
-			support_channel: '#ft-origami',
+			support_email: data.support_email || 'origami.support@ft.com',
+			support_channel: data.support_channel || '#ft-origami',
 			tag: 'v1.0.0',
 			version: '1.0.0',
 			version_major: 1,
@@ -139,6 +139,14 @@ exports.seed = async database => {
 			name: 'kumquat',
 			type: 'imageset',
 			support_status: 'maintained'
+		}),
+
+		version({
+			name: 'next-module',
+			type: 'module',
+			support_status: 'active',
+			support_email: 'next.developers@ft.com',
+			support_channel: '#ft-next-dev'
 		}),
 
 	]);

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -298,6 +298,13 @@
 					<code>experimental</code>, <code>deprecated</code>, <code>dead</code>.
 					Any repository which <em>doesn't</em> have this status will not be output.
 				</dd>
+				<dt>supportEmail</dt>
+				<dd>
+					Specify a support email address (or a comma-delimited list of email addresses)
+					to filter repositories by. For example, to only return Origami-supported repositories,
+					use <code>origami.support@ft.com</code>. Any repository which <em>doesn't</em>
+					have this support email will not be output.
+				</dd>
 				<dt>type</dt>
 				<dd>
 					Specify an Origami repo type (or a comma-delimited list of types) to filter repositories by.


### PR DESCRIPTION
You can now specify a query parameter of `?supportEmail=XXXXX` to only
return repositories which have a support email set to your given value.

So to find only officially Origami-supported components:

```
curl \
	-H 'X-Api-Key: XXXXXX' -H 'X-Api-Secret: XXXXXX' \
	https://origami-repo-data.ft.com/v1/repos?supportEmail=origami.support@ft.com
```