### PR TITLE
Alias an origamiType of component to module

### DIFF
--- a/models/version.js
+++ b/models/version.js
@@ -692,6 +692,11 @@ function initModel(app) {
 				normalisedManifest.origamiType = null;
 			}
 
+			// Convert the "component" origamiType to "module" in the database
+			if (normalisedManifest.origamiType === 'component') {
+				normalisedManifest.origamiType = 'module';
+			}
+
 			// Ensure that support status is a string or null
 			if (typeof normalisedManifest.support !== 'string') {
 				normalisedManifest.support = null;


### PR DESCRIPTION
This is a first step towards supporting Origami projects having an
`origamiType` property of `component` in their manifests. Right now
we're aliasing it to `module` in repo-data, later we can switch this
behaviour but this is the simplest way to make sure that repo data and
the registry continue to work.

There's a lack of testing around our models at the moment - the
ingestion process isn't actually run in any tests which is a bit of a
worry. I think I'll remedy this separately.

This closes #138.