### PR TITLE
Update documentation to use latest majors of Origami components

### DIFF
--- a/views/api/authentication.html
+++ b/views/api/authentication.html
@@ -18,7 +18,7 @@
 	The headers or query parameters required by the service are:
 </p>
 
-<table>
+<table class="o-table">
 	<thead>
 		<tr>
 			<th>Header</th>

--- a/views/index.html
+++ b/views/index.html
@@ -11,17 +11,17 @@
 <div class="o-layout__main o-layout-typography">
 
 	{{#if origami.options.enableSetupStep}}
-		<div class="o-message o-message--notice-inner o-message--warning-light" data-o-message-close=false data-o-component="o-message" style="margin-bottom:20px;">
+		<div class="o-message o-message--notice o-message--inner o-message--warning-light" data-close="false" data-o-component="o-message" style="margin-bottom:20px;">
 			<div class="o-message__container">
 				<div class="o-message__content">
-					<p class="o-message__content-highlight">Service Set Up</p>
 					<p class="o-message__content-main">
+						<span class="o-message__content-highlight">Service Set Up</span>
 						{{#if setupCredentials}}
 							The API key and secret below will only ever be output once. Do not
 							refresh this page or navigate away until you've saved the credentials
 							somewhere secure, such as Vault.
-	<pre><code class="nohighlight"><b>API Key:</b> {{setupCredentials.id}}
-			<b>API Secret:</b> {{setupCredentials.secret}}</code></pre>
+							<pre><code class="nohighlight"><b>API Key:</b> {{setupCredentials.id}}
+<b>API Secret:</b> {{setupCredentials.secret}}</code></pre>
 						{{else}}
 							Please remove the <code>ENABLE_SETUP_STEP</code> environment
 							variable from the service configuration.

--- a/views/layouts/landing.html
+++ b/views/layouts/landing.html
@@ -11,10 +11,6 @@
 			{{> header}}
 		</div>
 
-		<div class="o-layout__sidebar">
-			<!-- automatically generated sidebar -->
-		</div>
-
 		{{{body}}}
 
 		<div class="o-layout__footer">

--- a/views/partials/html-head.html
+++ b/views/partials/html-head.html
@@ -29,7 +29,7 @@
 	}
 </style>
 
-<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-layout@^3.1.8,o-header-services@^3.2.10,o-footer-services@^2.1.2,o-syntax-highlight@^1.5.1,o-fonts@^3.0.4,o-message@^2.4.0,o-table@^6.9.2&brand=internal" />
+<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-layout@^4.1.5,o-header-services@^4.0.3,o-footer-services@^3.0.2,o-syntax-highlight@^3.0.1,o-fonts@^4.3.2,o-message@^4.1.1,o-table@^8.0.5&brand=internal" />
 <link rel="stylesheet" href="/main.css" />
 <script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
 <script>
@@ -40,5 +40,5 @@
 			var s = document.getElementsByTagName('script')[0];
 			s.parentNode.insertBefore(script, s);
 		}
-	}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-layout@^3.1.8,o-header-services@^3.2.10,o-footer-services@^2.1.2,o-syntax-highlight@^1.5.1,o-message@^2.4.0,o-table@^6.9.2'));
+	}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-layout@^4.1.5,o-header-services@^4.0.3,o-footer-services@^3.0.2,o-syntax-highlight@^3.0.1,o-fonts@^4.3.2,o-message@^4.1.1,o-table@^8.0.5'));
 </script>


### PR DESCRIPTION
Not much needed changing, but I also decided to fix the weird homepage misalignment. Resolves #141.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<thead>
<tbody>
<tr>
<td><img src="https://user-images.githubusercontent.com/138944/78774852-2d904280-798d-11ea-8be7-15ffd1882b41.png" alt="Before" /></td>
<td><img src="https://user-images.githubusercontent.com/138944/78774857-2f5a0600-798d-11ea-9e10-b39b435041fc.png" alt="After" /></td>
</tr>
<tbody>
</table>