### PR TITLE
Change from Silver to Bronze

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -4,7 +4,7 @@ Origami Repo Data is an API which can be used to get information about repositor
 
 ## Service Tier
 
-Silver
+Bronze
 
 ## Lifecycle Stage
 


### PR DESCRIPTION
This application is only used in three places, all of which are not production-critical.
slack-webhook for announcing releases
origami-component-converter for compiling components to npm version before publishing
origami-registry-ui for displaying components (this service is bronze).