### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1702,9 +1702,9 @@
       "dev": true
     },
     "bl": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",


### PR DESCRIPTION
### Updated (1)

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [bl](https://npm.im/bl) | `4.0.2` → `4.0.3` | [github](https://github.com/rvagg/bl) | **[High]** Remote Memory Exposure ([ref](https://npmjs.com/advisories/1555)) |

***

This pull request is created by [npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action). The used npm version is **6.14.8**.