### PR TITLE
Interpret spaces as the boundaries of fuzzy search

### DIFF
--- a/models/version.js
+++ b/models/version.js
@@ -433,8 +433,12 @@ function initModel(app) {
 			// Create a regular expression for the search
 			let search;
 			if (filters.search && typeof filters.search === 'string') {
-				const regExpSafeQuery = filters.search.trim().replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
-				const searchRegExp = new RegExp(`${regExpSafeQuery}`, 'i');
+				const regExpQuery = filters.search.trim()
+				  // backslash escape special regular expression characters 
+				  .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
+				  // replace spaces with dot-star, for fuzzy searching
+				  .replace(/\s+/g, '.*');
+				const searchRegExp = new RegExp(`${regExpQuery}`, 'i');
 				search = searchRegExp.test.bind(searchRegExp);
 			}
 


### PR DESCRIPTION
This is to allow a search for "image service" to return the origami image service
this seems expectable based on what we have now.

(if you type "heads" you get "headshot-images", but "head image" gets you 0 results)

other options:
- split the repo name by name and check each word
- convert spaces to hyphens and try testing the repo name again, if the first test fails