### PR TITLE
Add standard origami service deployment workflow

### DIFF
--- a/.github/workflows/deploy-to-dev-and-test.yml
+++ b/.github/workflows/deploy-to-dev-and-test.yml
@@ -1,0 +1,24 @@
+name: Deploy to dev
+on: [pull_request]
+
+jobs:
+  deploy-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow
+      - name: Deploy to Heroku
+        run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-repo-data-dev.git HEAD:refs/heads/master --force
+
+  create-change-log:
+    needs: [deploy-dev]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Financial-Times/change-api-action@v1
+        name: Create new change log
+        with:
+          change-api-key: ${{ secrets.CHANGE_API_KEY }}
+          system-code: "origami-repo-data"
+          environment: dev
+          slack-channels: "ft-changes,origami-deploys"

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -1,0 +1,26 @@
+name: Deploy to production
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy-to-production:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: git fetch --prune --unshallow
+    - run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-repo-data-eu.git HEAD:refs/heads/master --force
+    - run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-repo-data-us.git HEAD:refs/heads/master --force
+
+  create-change-log:
+    needs: [deploy-to-production]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Financial-Times/change-api-action@v1
+        name: Create new change log
+        with:
+          change-api-key: ${{ secrets.CHANGE_API_KEY }}
+          system-code: "origami-repo-data"
+          environment: prod
+          slack-channels: "ft-changes,origami-deploys"

--- a/.github/workflows/deploy-to-staging-and-test.yml
+++ b/.github/workflows/deploy-to-staging-and-test.yml
@@ -1,0 +1,26 @@
+name: Deploy to staging
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy-to-staging:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: git fetch --prune --unshallow
+    - run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-repo-data-qa.git HEAD:refs/heads/master --force
+
+  create-change-log:
+    needs: [deploy-to-staging]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Financial-Times/change-api-action@v1
+        name: Create new change log
+        with:
+          change-api-key: ${{ secrets.CHANGE_API_KEY }}
+          system-code: "origami-repo-data"
+          environment: test
+          slack-channels: "ft-changes,origami-deploys"


### PR DESCRIPTION
The two secrets have been added to the repo's secrets section -- https://github.com/Financial-Times/origami-repo-data/settings/secrets/actions