### PR TITLE
Add `isPeer` to the Dependency Entity.

### DIFF
--- a/models/version.js
+++ b/models/version.js
@@ -140,7 +140,7 @@ function initModel(app) {
 						data: manifests[name]
 					};
 				});
-			const dependencyKeys = ['dependencies', 'devDependencies', 'optionalDependencies'];
+			const dependencyKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'];
 			const dependencies = [];
 
 			// If the repo has either a bower or package manifest...
@@ -154,6 +154,7 @@ function initModel(app) {
 									version,
 									source: (manifest.name === 'bower' ? 'bower' : 'npm'),
 									isDev: (dependencyKey === 'devDependencies'),
+									isPeer: (dependencyKey === 'peerDependencies'),
 									isOptional: (dependencyKey === 'optionalDependencies')
 								});
 							}
@@ -434,7 +435,7 @@ function initModel(app) {
 			let search;
 			if (filters.search && typeof filters.search === 'string') {
 				const regExpQuery = filters.search.trim()
-				  // backslash escape special regular expression characters 
+				  // backslash escape special regular expression characters
 				  .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
 				  // replace spaces with dot-star, for fuzzy searching
 				  .replace(/\s+/g, '.*');

--- a/test/integration/routes/v1-repos-(id)-versions-(id)-dependencies.test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(id)-dependencies.test.js
@@ -41,7 +41,8 @@ describe('GET /v1/repos/:repoId/versions/:versionId/dependencies', () => {
 				version: '^1.2.3',
 				source: 'bower',
 				isDev: false,
-				isOptional: false
+				isOptional: false,
+				isPeer: false
 			});
 
 			const dependency2 = response[1];
@@ -51,7 +52,8 @@ describe('GET /v1/repos/:repoId/versions/:versionId/dependencies', () => {
 				version: '^4.5.6',
 				source: 'bower',
 				isDev: false,
-				isOptional: false
+				isOptional: false,
+				isPeer: false
 			});
 
 			const dependency3 = response[2];
@@ -61,7 +63,8 @@ describe('GET /v1/repos/:repoId/versions/:versionId/dependencies', () => {
 				version: '^1.2.3',
 				source: 'bower',
 				isDev: true,
-				isOptional: false
+				isOptional: false,
+				isPeer: false
 			});
 
 			const dependency4 = response[3];
@@ -71,7 +74,8 @@ describe('GET /v1/repos/:repoId/versions/:versionId/dependencies', () => {
 				version: '^4.5.6',
 				source: 'bower',
 				isDev: true,
-				isOptional: false
+				isOptional: false,
+				isPeer: false
 			});
 
 		});
@@ -115,7 +119,8 @@ describe('GET /v1/repos/:repoId/versions/:versionId/dependencies', () => {
 					version: '^1.2.3',
 					source: 'bower',
 					isDev: false,
-					isOptional: false
+					isOptional: false,
+					isPeer: false
 				});
 
 				const dependency2 = response[1];
@@ -125,7 +130,8 @@ describe('GET /v1/repos/:repoId/versions/:versionId/dependencies', () => {
 					version: '^4.5.6',
 					source: 'bower',
 					isDev: false,
-					isOptional: false
+					isOptional: false,
+					isPeer: false
 				});
 
 				const dependency3 = response[2];
@@ -135,7 +141,8 @@ describe('GET /v1/repos/:repoId/versions/:versionId/dependencies', () => {
 					version: '^1.2.3',
 					source: 'npm',
 					isDev: false,
-					isOptional: false
+					isOptional: false,
+					isPeer: false
 				});
 
 				const dependency4 = response[3];
@@ -145,7 +152,8 @@ describe('GET /v1/repos/:repoId/versions/:versionId/dependencies', () => {
 					version: '^4.5.6',
 					source: 'npm',
 					isDev: false,
-					isOptional: false
+					isOptional: false,
+					isPeer: false
 				});
 
 				const dependency5 = response[4];
@@ -155,7 +163,8 @@ describe('GET /v1/repos/:repoId/versions/:versionId/dependencies', () => {
 					version: '^1.2.3',
 					source: 'npm',
 					isDev: true,
-					isOptional: false
+					isOptional: false,
+					isPeer: false
 				});
 
 				const dependency6 = response[5];
@@ -165,7 +174,8 @@ describe('GET /v1/repos/:repoId/versions/:versionId/dependencies', () => {
 					version: '^4.5.6',
 					source: 'npm',
 					isDev: true,
-					isOptional: false
+					isOptional: false,
+					isPeer: false
 				});
 
 				const dependency7 = response[6];
@@ -175,7 +185,19 @@ describe('GET /v1/repos/:repoId/versions/:versionId/dependencies', () => {
 					version: '^1.2.3',
 					source: 'npm',
 					isDev: false,
-					isOptional: true
+					isOptional: true,
+					isPeer: false
+				});
+
+				const dependency8 = response[7];
+				assert.isObject(dependency8);
+				assert.deepEqual(dependency8, {
+					name: 'mock-npm-dependency-6',
+					version: '^7.2.3',
+					source: 'npm',
+					isDev: false,
+					isOptional: true,
+					isPeer: false
 				});
 
 			});

--- a/test/integration/seed/basic/05-service.js
+++ b/test/integration/seed/basic/05-service.js
@@ -16,6 +16,9 @@ exports.seed = async database => {
 			},
 			optionalDependencies: {
 				'mock-npm-dependency-5': '^1.2.3'
+			},
+			peerDependencies: {
+				'mock-npm-dependency-6': '^7.2.3'
 			}
 		},
 		bower: {

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -207,6 +207,9 @@
 	// Whether the dependency is a development dependency
 	"isDev": false,
 
+	// Whether the dependency is a peer dependency
+	"isPeer": false,
+
 	// Whether the dependency is optional (npm only)
 	"isOptional": false
 }</code></pre>


### PR DESCRIPTION
This will allow Repo Data to surface npm peer dependencies, e.g. to support the
proposal to drop Bower support for components:
https://github.com/Financial-Times/origami/blob/npm/proposals/accepted/0000-npm.md