### PR TITLE
Add an `origamiVersion` filter to the repos endpoint.

### DIFF
--- a/lib/routes/v1/repos.js
+++ b/lib/routes/v1/repos.js
@@ -76,7 +76,7 @@ module.exports = app => {
 			origamiVersion: request.query.origamiVersion,
 		};
 
-		const hasFilters = Object.values(filters).filter(Boolean).length >= 1;
+		const hasFilters = Object.values(filters).some(Boolean);
 
 		try {
 			const repos = (

--- a/lib/routes/v1/repos.js
+++ b/lib/routes/v1/repos.js
@@ -72,15 +72,11 @@ module.exports = app => {
 			type: request.query.type,
 			status: request.query.status,
 			supportEmail: request.query.supportEmail,
-			search: request.query.q
+			search: request.query.q,
+			origamiVersion: request.query.origamiVersion,
 		};
-		const hasFilters = (
-			filters.brand ||
-			filters.type ||
-			filters.status ||
-			filters.supportEmail ||
-			filters.search
-		);
+
+		const hasFilters = Object.values(filters).filter(Boolean).length >= 1;
 
 		try {
 			const repos = (

--- a/models/version.js
+++ b/models/version.js
@@ -456,6 +456,7 @@ function initModel(app) {
 				.filter(propertyFilter('type', filters.type))
 				.filter(propertyFilter('support_email', filters.supportEmail))
 				.filter(propertyFilter('support_status', filters.status))
+				.filter(propertyFilter('origami_version', filters.origamiVersion))
 				.filter(repo => {
 					repo.searchScore = 0;
 					if (!search) {

--- a/test/integration/routes/v1-repos.test.js
+++ b/test/integration/routes/v1-repos.test.js
@@ -92,7 +92,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains only actively supported repos', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 5);
+				assert.lengthEquals(response, 6);
 				for (const repo of response) {
 					assert.strictEqual(repo.support.status, 'active');
 				}
@@ -200,7 +200,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains only module components', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 7);
+				assert.lengthEquals(response, 8);
 				for (const repo of response) {
 					assert.strictEqual(repo.type, 'module');
 				}
@@ -236,7 +236,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains only components with the expected support email', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 9);
+				assert.lengthEquals(response, 10);
 				for (const repo of response) {
 					assert.strictEqual(repo.support.email, 'origami.support@ft.com');
 				}
@@ -308,7 +308,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains components with either support email', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 10);
+				assert.lengthEquals(response, 11);
 				for (const repo of response) {
 					assert.include(['origami.support@ft.com', 'next.developers@ft.com'], repo.support.email);
 				}
@@ -380,7 +380,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains both module and service components', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 8);
+				assert.lengthEquals(response, 9);
 				for (const repo of response) {
 					assert.include(['module', 'service'], repo.type);
 				}
@@ -488,7 +488,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains only components which have not been branded', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 6);
+				assert.lengthEquals(response, 7);
 				for (const repo of response) {
 					if (repo.type === 'module') {
 						assert.deepEqual(repo.brands, []);
@@ -682,6 +682,113 @@ describe('GET /v1/repos with query:', () => {
 				assert.isArray(response);
 				assert.lengthEquals(response, 1);
 				assert.strictEqual(response[0].name, 'new-module (banana)');
+			});
+
+		});
+
+	});
+
+	describe('origamiVersion=1', () => {
+
+		beforeEach(async () => {
+			request = agent
+				.get('/v1/repos?origamiVersion=1')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 200 status', () => {
+			return request.expect(200);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains components which match all criteria', () => {
+				assert.isArray(response);
+				assert.greaterThan(response.length, 0, 'No components returned.');
+				response.forEach(component => {
+					assert.strictEqual(component.origamiVersion, '1', `Returned "${component.name}" with Origami version "${component.origamiVersion}".`);
+				});
+			});
+
+		});
+
+	});
+
+	describe('origamiVersion=2.0', () => {
+
+		beforeEach(async () => {
+			request = agent
+				.get('/v1/repos?origamiVersion=2.0')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 200 status', () => {
+			return request.expect(200);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains components which match all criteria', () => {
+				assert.isArray(response);
+				assert.greaterThan(response.length, 0, 'No components returned.');
+				response.forEach(component => {
+					assert.strictEqual(component.origamiVersion, '2.0', `Returned "${component.name}" with Origami version "${component.origamiVersion}".`);
+				});
+			});
+
+		});
+
+	});
+
+	describe('origamiVersion=1,2.0', () => {
+
+		beforeEach(async () => {
+			request = agent
+				.get('/v1/repos?origamiVersion=1,2.0')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 200 status', () => {
+			return request.expect(200);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains components which match all criteria', () => {
+				assert.isArray(response);
+				assert.greaterThan(response.length, 0, 'No components returned.');
+				assert.ok(response.find(c => c.origamiVersion === '1'), 'Expected to find a v1 component');
+				assert.ok(response.find(c => c.origamiVersion === '2.0'), 'Expected to find a v2.0 component');
 			});
 
 		});

--- a/test/integration/seed/basic/03-imageset.js
+++ b/test/integration/seed/basic/03-imageset.js
@@ -7,6 +7,7 @@ exports.seed = async database => {
 		origami: {
 			name: 'o-mock-imageset',
 			origamiType: 'imageset',
+			origamiVersion: '1',
 			isMockManifest: true
 		},
 		imageSet: {

--- a/test/integration/seed/basic/05-service.js
+++ b/test/integration/seed/basic/05-service.js
@@ -4,6 +4,9 @@
 exports.seed = async database => {
 
 	const manifests = {
+		origami: {
+			origamiVersion: '1',
+		},
 		package: {
 			name: 'o-mock-component',
 			dependencies: {

--- a/test/integration/seed/search/repos.js
+++ b/test/integration/seed/search/repos.js
@@ -29,7 +29,8 @@ exports.seed = async database => {
 				origami: {
 					brands: [],
 					keywords: [],
-					demos: []
+					demos: [],
+					origamiVersion: '1',
 				}
 			}
 		});
@@ -52,6 +53,21 @@ exports.seed = async database => {
 						'master',
 						'internal'
 					]
+				}
+			}
+		}),
+
+		version({
+			name: 'active-module-v2',
+			type: 'module',
+			support_status: 'active',
+			origami_version: '2.0',
+			manifests: {
+				origami: {
+					description: 'this follows the 2.0 origami specification',
+					keywords: [],
+					origamiVersion: '2.0',
+					brands: []
 				}
 			}
 		}),

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -317,6 +317,11 @@
 					Possible values are: <code>module</code>, <code>service</code>, <code>imageset</code>.
 					Any repository which <em>doesn't</em> have this type will not be output.
 				</dd>
+				<dt>origamiVersion</dt>
+				<dd>
+					Specify an Origami specification version (or a comma-delimited list of versions) to filter repositories by.
+					For example: <code>1</code>, <code>2.0</code>, <code>1,2.0</code>.
+				</dd>
 			</dl>
 		</td>
 	</tr>


### PR DESCRIPTION
This will allow Repo Data to more easily surface what versions
of Origami projects are using v1 of the Origami spec vs. a later
version of the spec.

This is to support the proposal to drop Bower support for components:
https://github.com/Financial-Times/origami/blob/npm/proposals/accepted/0000-npm.md