### PR TITLE
Allow origami version to be the "2.0" string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Origami Repo Data
 
 Get information about Origami repositories. See [the production service][production-url] for API information.

--- a/data/seed/demo/example-component-v2.js
+++ b/data/seed/demo/example-component-v2.js
@@ -55,7 +55,7 @@ exports.seed = async database => {
                         'internal'
                     ],
                     keywords: 'example, mock',
-                    origamiVersion: 2,
+                    origamiVersion: "2.0",
                     support: 'https://github.com/Financial-Times/o-example-component-v2/issues',
                     supportStatus: 'active',
                     demos: demos
@@ -97,7 +97,7 @@ exports.seed = async database => {
                     origamiType: 'module',
                     origamiCategory: 'components',
                     keywords: 'example, mock',
-                    origamiVersion: 2,
+                    origamiVersion: "2.0",
                     support: 'https://github.com/Financial-Times/o-example-component-v2/issues',
                     supportStatus: 'active',
                     demos: demos
@@ -139,7 +139,7 @@ exports.seed = async database => {
                     origamiType: 'module',
                     origamiCategory: 'components',
                     keywords: 'example, mock',
-                    origamiVersion: 2,
+                    origamiVersion: "2.0",
                     support: 'https://github.com/Financial-Times/o-example-component-v2/issues',
                     supportStatus: 'active',
                     demos: demos

--- a/data/seed/demo/example-component-v2.js
+++ b/data/seed/demo/example-component-v2.js
@@ -55,7 +55,7 @@ exports.seed = async database => {
                         'internal'
                     ],
                     keywords: 'example, mock',
-                    origamiVersion: "2.0",
+                    origamiVersion: '2.0',
                     support: 'https://github.com/Financial-Times/o-example-component-v2/issues',
                     supportStatus: 'active',
                     demos: demos
@@ -97,7 +97,7 @@ exports.seed = async database => {
                     origamiType: 'module',
                     origamiCategory: 'components',
                     keywords: 'example, mock',
-                    origamiVersion: "2.0",
+                    origamiVersion: '2.0',
                     support: 'https://github.com/Financial-Times/o-example-component-v2/issues',
                     supportStatus: 'active',
                     demos: demos
@@ -139,7 +139,7 @@ exports.seed = async database => {
                     origamiType: 'module',
                     origamiCategory: 'components',
                     keywords: 'example, mock',
-                    origamiVersion: "2.0",
+                    origamiVersion: '2.0',
                     support: 'https://github.com/Financial-Times/o-example-component-v2/issues',
                     supportStatus: 'active',
                     demos: demos

--- a/models/version.js
+++ b/models/version.js
@@ -440,7 +440,26 @@ function initModel(app) {
 				.filter(propertyFilter('type', filters.type))
 				.filter(propertyFilter('support_email', filters.supportEmail))
 				.filter(propertyFilter('support_status', filters.status))
-				.filter(propertyFilter('origami_version', filters.origamiVersion))
+				.filter(repo => {
+					const standardMatch = propertyFilter('origami_version', filters.origamiVersion);
+					
+					if (standardMatch(repo)) {
+						return true;
+					}
+					
+					if (filters.origamiVersion.match(/\d+/)) {
+						const repoOrigamiVersion = repo.get('origami_version');
+						if (!repoOrigamiVersion) {
+							return false;
+						}
+						const major = repoOrigamiVersion.split('.')[0];
+						if (major === filters.origamiVersion) {
+							return true;
+						}
+					}
+					
+					return false;
+				})
 				.filter(repo => {
 					repo.searchScore = 0;
 					if (!search) {

--- a/test/integration/routes/v1-repos-(id)-versions.test.js
+++ b/test/integration/routes/v1-repos-(id)-versions.test.js
@@ -45,7 +45,7 @@ describe('GET /v1/repos/:repoId/versions', () => {
 			assert.strictEqual(version2.name, 'o-mock-component');
 			assert.strictEqual(version2.version, '3.0.0');
 			assert.strictEqual(version2.versionTag, 'v3.0.0');
-			assert.strictEqual(version2.origamiVersion, '2');
+			assert.strictEqual(version2.origamiVersion, '2.0');
 
 			const version3 = response[2];
 			assert.isObject(version3);

--- a/test/integration/routes/v1-repos.test.js
+++ b/test/integration/routes/v1-repos.test.js
@@ -724,7 +724,7 @@ describe('GET /v1/repos with query:', () => {
 
 	});
 
-		describe('origamiVersion=2.0', () => {
+	describe('origamiVersion=2.0', () => {
 
 		beforeEach(async () => {
 			request = agent
@@ -760,6 +760,7 @@ describe('GET /v1/repos with query:', () => {
 
 	});
 
+	describe.only('origamiVersion=2', () => {
 
 		beforeEach(async () => {
 			request = agent
@@ -786,8 +787,10 @@ describe('GET /v1/repos with query:', () => {
 			it('contains components which match all criteria', () => {
 				assert.isArray(response);
 				assert.greaterThan(response.length, 0, 'No components returned.');
+				assert.ok(response.find(c => c.origamiVersion === '2.0'), 'Expected to find a v2.0 component');
+				assert.ok(response.find(c => c.origamiVersion === '2.1'), 'Expected to find a v2.1 component');
 				response.forEach(component => {
-					assert.strictEqual(component.origamiVersion, '2', `Returned "${component.name}" with Origami version "${component.origamiVersion}".`);
+					assert(component.origamiVersion.startsWith('2.'), `Returned "${component.name}" with Origami version "${component.origamiVersion}".`);
 				});
 			});
 

--- a/test/integration/routes/v1-repos.test.js
+++ b/test/integration/routes/v1-repos.test.js
@@ -92,7 +92,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains only actively supported repos', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 6);
+				assert.lengthEquals(response, 7);
 				for (const repo of response) {
 					assert.strictEqual(repo.support.status, 'active');
 				}
@@ -200,7 +200,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains only module components', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 8);
+				assert.lengthEquals(response, 9);
 				for (const repo of response) {
 					assert.strictEqual(repo.type, 'module');
 				}
@@ -236,7 +236,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains only components with the expected support email', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 10);
+				assert.lengthEquals(response, 11);
 				for (const repo of response) {
 					assert.strictEqual(repo.support.email, 'origami.support@ft.com');
 				}
@@ -308,7 +308,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains components with either support email', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 11);
+				assert.lengthEquals(response, 12);
 				for (const repo of response) {
 					assert.include(['origami.support@ft.com', 'next.developers@ft.com'], repo.support.email);
 				}
@@ -380,7 +380,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains both module and service components', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 9);
+				assert.lengthEquals(response, 10);
 				for (const repo of response) {
 					assert.include(['module', 'service'], repo.type);
 				}
@@ -488,7 +488,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains only components which have not been branded', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 7);
+				assert.lengthEquals(response, 8);
 				for (const repo of response) {
 					if (repo.type === 'module') {
 						assert.deepEqual(repo.brands, []);

--- a/test/integration/routes/v1-repos.test.js
+++ b/test/integration/routes/v1-repos.test.js
@@ -724,7 +724,42 @@ describe('GET /v1/repos with query:', () => {
 
 	});
 
-	describe('origamiVersion=2', () => {
+		describe('origamiVersion=2.0', () => {
+
+		beforeEach(async () => {
+			request = agent
+				.get('/v1/repos?origamiVersion=2.0')
+				.set('X-Api-Key', 'mock-read-key')
+				.set('X-Api-Secret', 'mock-read-secret');
+		});
+
+		it('responds with a 200 status', () => {
+			return request.expect(200);
+		});
+
+		it('responds with JSON', () => {
+			return request.expect('Content-Type', /application\/json/);
+		});
+
+		describe('JSON response', () => {
+			let response;
+
+			beforeEach(async () => {
+				response = (await request.then()).body;
+			});
+
+			it('contains components which match all criteria', () => {
+				assert.isArray(response);
+				assert.greaterThan(response.length, 0, 'No components returned.');
+				response.forEach(component => {
+					assert.strictEqual(component.origamiVersion, '2.0', `Returned "${component.name}" with Origami version "${component.origamiVersion}".`);
+				});
+			});
+
+		});
+
+	});
+
 
 		beforeEach(async () => {
 			request = agent
@@ -760,11 +795,11 @@ describe('GET /v1/repos with query:', () => {
 
 	});
 
-	describe('origamiVersion=1,2', () => {
+	describe('origamiVersion=1,2.0', () => {
 
 		beforeEach(async () => {
 			request = agent
-				.get('/v1/repos?origamiVersion=1,2')
+				.get('/v1/repos?origamiVersion=1,2.0')
 				.set('X-Api-Key', 'mock-read-key')
 				.set('X-Api-Secret', 'mock-read-secret');
 		});
@@ -788,7 +823,7 @@ describe('GET /v1/repos with query:', () => {
 				assert.isArray(response);
 				assert.greaterThan(response.length, 0, 'No components returned.');
 				assert.ok(response.find(c => c.origamiVersion === '1'), 'Expected to find a v1 component');
-				assert.ok(response.find(c => c.origamiVersion === '2'), 'Expected to find a v2 component');
+				assert.ok(response.find(c => c.origamiVersion === '2.0'), 'Expected to find a v2 component');
 			});
 
 		});

--- a/test/integration/routes/v1-repos.test.js
+++ b/test/integration/routes/v1-repos.test.js
@@ -760,7 +760,7 @@ describe('GET /v1/repos with query:', () => {
 
 	});
 
-	describe.only('origamiVersion=2', () => {
+	describe('origamiVersion=2', () => {
 
 		beforeEach(async () => {
 			request = agent

--- a/test/integration/seed/basic/01-component.js
+++ b/test/integration/seed/basic/01-component.js
@@ -189,7 +189,7 @@ exports.seed = async database => {
 			languages: JSON.stringify(['js', 'scss']),
 			manifests: JSON.stringify(Object.assign({}, manifestsV1, {
 				origami: Object.assign({}, manifestsV1.origami, {
-					origamiVersion: 2
+					origamiVersion: '2.0'
 				}),
 				package: {
 					'name': `@financial-times/${manifestsV1.origami.name}`,

--- a/test/integration/seed/search/repos.js
+++ b/test/integration/seed/search/repos.js
@@ -61,12 +61,16 @@ exports.seed = async database => {
 			name: 'active-module-v2',
 			type: 'module',
 			support_status: 'active',
-			origami_version: '2',
+			origami_version: '2.0',
 			manifests: {
 				origami: {
 					description: 'this follows the v2 origami specification',
 					keywords: [],
-					origamiVersion: 2,
+					origamiVersion: '2.0',
+					brands: []
+				}
+			}
+		}),
 					brands: []
 				}
 			}

--- a/test/integration/seed/search/repos.js
+++ b/test/integration/seed/search/repos.js
@@ -71,6 +71,17 @@ exports.seed = async database => {
 				}
 			}
 		}),
+
+		version({
+			name: 'active-module-v2.1',
+			type: 'module',
+			support_status: 'active',
+			origami_version: '2.1',
+			manifests: {
+				origami: {
+					description: 'this follows the v2.1 origami specification',
+					keywords: [],
+					origamiVersion: '2.1',
 					brands: []
 				}
 			}


### PR DESCRIPTION
This also adds the feature that asking for `origamiVersion=2` will provide all components with an origamiVersion a major version of 2.

i was unable to use the semver module for this, because it does not believe `"2.0"` satisfies `"2"`.