### PR TITLE
Add "migration" to delete duplicate records.

### DIFF
--- a/data/migration/20210420151324_delete-duplicates.js
+++ b/data/migration/20210420151324_delete-duplicates.js
@@ -1,0 +1,32 @@
+
+'use strict';
+
+
+exports.up = async database => {
+
+    const results = await database.raw('SELECT * FROM (SELECT DISTINCT name, version, COUNT(*) FROM versions GROUP BY name, version) as foo WHERE count > 1 ORDER BY count DESC;');
+
+    for (const result of results.rows) {
+
+        const duplicates = await database.raw(
+            `SELECT id, name, version, updated_at FROM versions WHERE name = '${result.name}' AND version='${result.version}' ORDER BY updated_at;`
+        );
+
+        // Keep the most recent duplicate
+        const mostRecentDuplicate = duplicates.rows.pop();
+        const oldDuplicates = duplicates.rows;
+
+        console.log(`Keeping: ${JSON.stringify(mostRecentDuplicate)}.\nDeleting: ${oldDuplicates.map(d => d.id)}\n\n`);
+
+        await database('bundles')
+            .whereIn('version_id', oldDuplicates.map(d => d.id))
+            .del();
+
+        await database('versions')
+            .whereIn('id', oldDuplicates.map(d => d.id))
+            .del();
+    }
+};
+exports.down = function() {
+    // there's no going back (other than a manual db restore, or re-ingesting versions)
+};


### PR DESCRIPTION
This will delete 621 duplicates across 217 versions, plus
releases made today.

Some duplicates are caused by a fixed ingestion error:
https://github.com/Financial-Times/origami-repo-data/pull/321

Others due to multiple tags of the same version (not fixed,
with automated tagging this is less likely to happen, and we
may decommission repo data):
https://github.com/Financial-Times/origami-repo-data/issues/123

Rollback plan: restore from manual backup. I created a manual
backup this morning which we can restore from (see heroku >
resources).