### PR TITLE
Log bundle sizes on ingestion only for component releases.

### DIFF
--- a/lib/ingestion-queue-processor.js
+++ b/lib/ingestion-queue-processor.js
@@ -61,8 +61,10 @@ module.exports = class IngestionQueueProcessor {
 					await this.app.slackAnnouncer.announce(version);
 
 					// Queue a Bundle Ingestion for this Version
-					const bundleIngestion = await this.Ingestion.create(url, tag, 'bundle');
-					await bundleIngestion.save();
+					if (version.get('type') === 'module' || version.get('type') === 'component') {
+						const bundleIngestion = await this.Ingestion.create(url, tag, 'bundle');
+						await bundleIngestion.save();
+					}
 				}
 
 				// Process bundle ingestion

--- a/test/unit/lib/ingestion-queue-processor.test.js
+++ b/test/unit/lib/ingestion-queue-processor.test.js
@@ -135,10 +135,11 @@ describe('lib/ingestion-queue-processor', () => {
 				global.setTimeout.restore();
 			});
 
-			describe('when a version ingestions is in the database', () => {
+			describe('when a version ingestion for a component is in the database', () => {
 
 				beforeEach(async () => {
 					mockIngestion.get.withArgs('type').returns('version');
+					mockVersion.get.withArgs('type').returns('component');
 					await fetchNextIngestion();
 				});
 
@@ -191,6 +192,19 @@ describe('lib/ingestion-queue-processor', () => {
 					global.setTimeout.firstCall.args[0]();
 					assert.calledOnce(instance.fetchNextIngestion);
 					assert.calledWithExactly(instance.fetchNextIngestion);
+				});
+			});
+
+			describe('when a version ingestion for a non-component is in the database', () => {
+
+				beforeEach(async () => {
+					mockIngestion.get.withArgs('type').returns('version');
+					mockVersion.get.withArgs('type').returns('lib');
+					await fetchNextIngestion();
+				});
+
+				it('does not create a bundle ingestion for the new version', () => {
+					assert.notCalled(app.model.Ingestion.create);
 				});
 			});
 


### PR DESCRIPTION
At the moment repo data sends Build Service requests for any
version ingestion, including for origami-build-tools.
https://sentry.io/organizations/financial-times/issues/2352116455/?environment=production&project=231984

We only really care about component bundle sizes.