### PR TITLE
Drop the "module" origami type for spec v2 components.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ db-create:
 	@createdb origami-repo-data
 	@$(DONE)
 
+db-drop:
+	@dropdb origami-repo-data
+	@$(DONE)
+
 db-create-test:
 	@createdb origami-repo-data-test
 	@$(DONE)

--- a/data/seed/demo/example-component-v1.js
+++ b/data/seed/demo/example-component-v1.js
@@ -66,7 +66,7 @@ exports.seed = async database => {
 				},
 				package: null
 			}),
-			languages: ['js'],
+			languages: JSON.stringify(['js']),
 			markdown: JSON.stringify({
 				designGuidelines: 'TODO add mock design guidelines',
 				migrationGuide: null,
@@ -109,7 +109,7 @@ exports.seed = async database => {
 				},
 				package: null
 			}),
-			languages: ['js', 'scss'],
+			languages: JSON.stringify(['js', 'scss']),
 			markdown: JSON.stringify({
 				designGuidelines: 'TODO add mock design guidelines',
 				migrationGuide: null,
@@ -152,7 +152,7 @@ exports.seed = async database => {
 				},
 				package: null
 			}),
-			languages: ['js', 'scss'],
+			languages: JSON.stringify(['js', 'scss']),
 			markdown: JSON.stringify({
 				designGuidelines: 'TODO add mock design guidelines',
 				migrationGuide: null,

--- a/data/seed/demo/example-component-v2.js
+++ b/data/seed/demo/example-component-v2.js
@@ -33,7 +33,7 @@ exports.seed = async database => {
             created_at: new Date(Date.now() - 10000),
             updated_at: new Date(Date.now() - 10000),
             name: 'o-example-component-v2',
-            type: 'module',
+            type: 'component',
             url: 'https://github.com/Financial-Times/o-example-component-v2',
             support_email: 'origami.support@ft.com',
             support_channel: '#origami-support',
@@ -48,7 +48,7 @@ exports.seed = async database => {
                 imageSet: null,
                 origami: {
                     description: 'An example Origami component, which follows v2 of the Origami specification',
-                    origamiType: 'module',
+                    origamiType: 'component',
                     origamiCategory: 'components',
                     brands: [
                         'master',
@@ -79,7 +79,7 @@ exports.seed = async database => {
             created_at: new Date(Date.now() - 5000),
             updated_at: new Date(Date.now() - 5000),
             name: 'o-example-component-v2',
-            type: 'module',
+            type: 'component',
             url: 'https://github.com/Financial-Times/o-example-component-v2',
             support_email: 'origami.support@ft.com',
             support_channel: '#origami-support',
@@ -94,7 +94,7 @@ exports.seed = async database => {
                 imageSet: null,
                 origami: {
                     description: 'An example Origami component, which follows v2 of the Origami specification',
-                    origamiType: 'module',
+                    origamiType: 'component',
                     origamiCategory: 'components',
                     keywords: 'example, mock',
                     origamiVersion: '2.0',
@@ -121,7 +121,7 @@ exports.seed = async database => {
             created_at: new Date(Date.now()),
             updated_at: new Date(Date.now()),
             name: 'o-example-component-v2',
-            type: 'module',
+            type: 'component',
             url: 'https://github.com/Financial-Times/o-example-component-v2',
             support_email: 'origami.support@ft.com',
             support_channel: '#origami-support',
@@ -136,7 +136,7 @@ exports.seed = async database => {
                 imageSet: null,
                 origami: {
                     description: 'An example Origami component, which follows v2 of the Origami specification',
-                    origamiType: 'module',
+                    origamiType: 'component',
                     origamiCategory: 'components',
                     keywords: 'example, mock',
                     origamiVersion: '2.0',

--- a/data/seed/demo/example-component-v2.js
+++ b/data/seed/demo/example-component-v2.js
@@ -66,7 +66,7 @@ exports.seed = async database => {
                     browser: './main.js'
                 }
             }),
-            languages: ['js'],
+            languages: JSON.stringify(['js']),
             markdown: JSON.stringify({
                 designGuidelines: 'TODO add mock design guidelines',
                 migrationGuide: null,
@@ -108,7 +108,7 @@ exports.seed = async database => {
                     browser: './main.js'
                 }
             }),
-            languages: ['js'],
+            languages: JSON.stringify(['js']),
             markdown: JSON.stringify({
                 designGuidelines: 'TODO add mock design guidelines',
                 migrationGuide: null,
@@ -153,7 +153,7 @@ exports.seed = async database => {
                     }
                 },
             }),
-            languages: ['js'],
+            languages: JSON.stringify(['js']),
             markdown: JSON.stringify({
                 designGuidelines: 'TODO add mock design guidelines',
                 migrationGuide: null,

--- a/data/seed/demo/example-node-module.js
+++ b/data/seed/demo/example-node-module.js
@@ -39,7 +39,7 @@ exports.seed = async database => {
 					dependencies: {}
 				}
 			}),
-			languages: ['js'],
+			languages: JSON.stringify(['js']),
 			markdown: JSON.stringify({
 				designGuidelines: null,
 				migrationGuide: null,
@@ -75,7 +75,7 @@ exports.seed = async database => {
 					dependencies: {}
 				}
 			}),
-			languages: ['js'],
+			languages: JSON.stringify(['js']),
 			markdown: JSON.stringify({
 				designGuidelines: null,
 				migrationGuide: null,

--- a/lib/create-version-from-ingestion/normalise-origami-manifest.js
+++ b/lib/create-version-from-ingestion/normalise-origami-manifest.js
@@ -15,8 +15,13 @@ module.exports = function normaliseOrigamiManifest(manifest) {
 		normalisedManifest.origamiType = null;
 	}
 
-	// Convert the "component" origamiType to "module" in the database
-	if (normalisedManifest.origamiType === 'component') {
+	// Convert the "component" origamiType to "module" in the database for
+	// spec v1 components. The "component" alias was introduced after "module"
+	// and any project using repo data should be able to continue to filter v1
+	// projects using the "module" type without requiring an update. However,
+	// spec v2 drops the "module" type for "component" only.
+	const specV1 = (!manifest.version || `${manifest.version}` === '1'); // assume falsy is spec v1, pre linting
+	if (specV1 && normalisedManifest.origamiType === 'component') {
 		normalisedManifest.origamiType = 'module';
 	}
 

--- a/lib/ingestion-queue-processor.js
+++ b/lib/ingestion-queue-processor.js
@@ -61,7 +61,7 @@ module.exports = class IngestionQueueProcessor {
 					await this.app.slackAnnouncer.announce(version);
 
 					// Queue a Bundle Ingestion for this Version
-					if (version.get('type') === 'module' || version.get('type') === 'component') {
+					if (version.get('type_is_component')) {
 						const bundleIngestion = await this.Ingestion.create(url, tag, 'bundle');
 						await bundleIngestion.save();
 					}

--- a/models/version.js
+++ b/models/version.js
@@ -171,6 +171,16 @@ function initModel(app) {
 		outputVirtuals: false,
 		virtuals: {
 
+			// Get whether the repo is a component. Either "module" or
+			// "component" could be used interchangeably for spec v1 components.
+			// It was normalised to "module" within repo data, however, spec v2
+			// components dropped the "module" type for "component",
+			type_is_component() {
+				return ['module', 'component'].includes(
+					this.get('type')
+				);
+			},
+
 			// Get whether the repo is supported by the Origami team
 			support_is_origami() {
 				return (this.get('support_email') === origamiSupportEmail);
@@ -651,7 +661,7 @@ function initModel(app) {
 
 		// Normalise an origami brands array
 		normaliseOrigamiBrandsArray(type, brands) {
-			if (type !== 'module') {
+			if (type !== 'module' && type !== 'component') {
 				return null;
 			}
 			if (!Array.isArray(brands)) {

--- a/test/integration/lib/create-version-from-ingestion.test.js
+++ b/test/integration/lib/create-version-from-ingestion.test.js
@@ -26,12 +26,13 @@ describe('createVersionFromIngestion', () => {
             proclaim.ok(version, 'No Version could be found for the Ingestion.');
             proclaim.include(version.get('languages'), 'js', 'Expected the Version to include "js" in the "languages" property.');
             proclaim.include(version.get('languages'), 'scss', 'Expected the Version to include "scss" in the "languages" property.');
+            proclaim.isTrue(version.get('type_is_component'), 'Expected the Version "type_is_component" property to be true.');
         });
     });
 
     describe('given a v2 component Ingestion', () => {
         describe('that is valid, with JS and Sass', () => {
-            it('saves a new Version with languages set', async () => {
+            it('saves a new Version with properties set', async () => {
                 const url = 'https://github.com/Financial-Times/o-test-component';
                 const tag = 'v2.0.1';
 
@@ -45,10 +46,11 @@ describe('createVersionFromIngestion', () => {
                 proclaim.ok(version, 'No Version could be found for the Ingestion.');
                 proclaim.include(version.get('languages'), 'js', 'Expected the Version to include "js" in the "languages" property.');
                 proclaim.include(version.get('languages'), 'scss', 'Expected the Version to include "scss" in the "languages" property.');
+                proclaim.isTrue(version.get('type_is_component'), 'Expected the Version "type_is_component" property to be true.');
             });
         });
         describe('that is valid, with JS but no Sass', () => {
-            it('saves a new Version with languages set', async () => {
+            it('saves a new Version with properties set', async () => {
                 const url = 'https://github.com/Financial-Times/o-test-component';
                 const tag = 'v2.0.16';
 
@@ -62,6 +64,7 @@ describe('createVersionFromIngestion', () => {
                 proclaim.ok(version, 'No Version could be found for the Ingestion.');
                 proclaim.include(version.get('languages'), 'js', 'Expected the Version to include "js" in the "languages" property.');
                 proclaim.notInclude(version.get('languages'), 'scss', 'Expected the Version to not include "scss" in the "languages" property, "js" only.');
+                proclaim.isTrue(version.get('type_is_component'), 'Expected the Version "type_is_component" property to be true.');
             });
         });
     });

--- a/test/integration/models/bundle.test.js
+++ b/test/integration/models/bundle.test.js
@@ -46,6 +46,7 @@ describe('Bundle', () => {
 				const url = new URL(this.req.options.href);
 				const { lang } = uri.match(/bundles\/(?<lang>[a-z]*)/).groups;
 				const brand = url.searchParams.get('brand');
+
 				const result = mockData.find(d =>
 					d.brand === brand &&
 					d.lang === lang

--- a/test/integration/routes/v1-repos.test.js
+++ b/test/integration/routes/v1-repos.test.js
@@ -490,7 +490,11 @@ describe('GET /v1/repos with query:', () => {
 				assert.isArray(response);
 				assert.lengthEquals(response, 8);
 				for (const repo of response) {
-					assert.deepEqual(repo.brands, []);
+					if (repo.type === 'module' || repo.type === 'component') {
+						assert.deepEqual(repo.brands, []);
+					} else {
+						assert.isNull(repo.brands);
+					}
 				}
 			});
 

--- a/test/integration/routes/v1-repos.test.js
+++ b/test/integration/routes/v1-repos.test.js
@@ -200,7 +200,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains only module components', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 9);
+				assert.lengthEquals(response, 7);
 				for (const repo of response) {
 					assert.strictEqual(repo.type, 'module');
 				}
@@ -380,7 +380,7 @@ describe('GET /v1/repos with query:', () => {
 
 			it('contains both module and service components', () => {
 				assert.isArray(response);
-				assert.lengthEquals(response, 10);
+				assert.lengthEquals(response, 8);
 				for (const repo of response) {
 					assert.include(['module', 'service'], repo.type);
 				}
@@ -490,11 +490,7 @@ describe('GET /v1/repos with query:', () => {
 				assert.isArray(response);
 				assert.lengthEquals(response, 8);
 				for (const repo of response) {
-					if (repo.type === 'module') {
-						assert.deepEqual(repo.brands, []);
-					} else {
-						assert.isNull(repo.brands);
-					}
+					assert.deepEqual(repo.brands, []);
 				}
 			});
 

--- a/test/integration/seed/basic/01-component.js
+++ b/test/integration/seed/basic/01-component.js
@@ -176,7 +176,7 @@ exports.seed = async database => {
 			created_at: new Date('2021-04-10T00:00:00Z'),
 			updated_at: new Date('2021-04-10T00:00:00Z'),
 			name: 'o-mock-component',
-			type: 'module',
+			type: 'component',
 			url: 'https://github.com/Financial-Times/o-mock-component',
 			support_email: 'origami.support@ft.com',
 			support_channel: '#origami-support',

--- a/test/integration/seed/search/repos.js
+++ b/test/integration/seed/search/repos.js
@@ -59,7 +59,7 @@ exports.seed = async database => {
 
 		version({
 			name: 'active-module-v2',
-			type: 'module',
+			type: 'component',
 			support_status: 'active',
 			origami_version: '2.0',
 			manifests: {
@@ -74,7 +74,7 @@ exports.seed = async database => {
 
 		version({
 			name: 'active-module-v2.1',
-			type: 'module',
+			type: 'component',
 			support_status: 'active',
 			origami_version: '2.1',
 			manifests: {

--- a/test/unit/lib/ingestion-queue-processor.test.js
+++ b/test/unit/lib/ingestion-queue-processor.test.js
@@ -140,6 +140,7 @@ describe('lib/ingestion-queue-processor', () => {
 				beforeEach(async () => {
 					mockIngestion.get.withArgs('type').returns('version');
 					mockVersion.get.withArgs('type').returns('component');
+					mockVersion.get.withArgs('type_is_component').returns(true);
 					await fetchNextIngestion();
 				});
 
@@ -200,6 +201,7 @@ describe('lib/ingestion-queue-processor', () => {
 				beforeEach(async () => {
 					mockIngestion.get.withArgs('type').returns('version');
 					mockVersion.get.withArgs('type').returns('lib');
+					mockVersion.get.withArgs('type_is_component').returns(false);
 					await fetchNextIngestion();
 				});
 

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -314,7 +314,7 @@
 				<dt>type</dt>
 				<dd>
 					Specify an Origami repo type (or a comma-delimited list of types) to filter repositories by.
-					Possible values are: <code>module</code>, <code>service</code>, <code>imageset</code>.
+					For example: <code>component</code>, <code>module</code>, <code>service</code>, <code>imageset</code>.
 					Any repository which <em>doesn't</em> have this type will not be output.
 				</dd>
 				<dt>origamiVersion</dt>


### PR DESCRIPTION
- Continue to normalise "component" to "module" for spec v1 components, which may
use either. "component" was added as an alias later, and we want any tooling to
be able to continue to work with v1 component results.
- Swap "module" for "component" as a type for spec v2 tests and seed data. Tests
for the filter query param show fewer results correctly, as the query is for
"module" which no longer returns spec v2 components.
- Create `Version` `type_is_component` virtual property so repo data may treat
v1 and v2 components the same by querying this property.

Conversation:
[Financial-Times/origami-website#273 (comment)](https://github.com/Financial-Times/origami-website/pull/273#discussion_r617396987)