### PR TITLE
Note "origamiCategory" is removed from spec v2 components

### DIFF
--- a/data/seed/demo/example-component-v2.js
+++ b/data/seed/demo/example-component-v2.js
@@ -49,7 +49,6 @@ exports.seed = async database => {
                 origami: {
                     description: 'An example Origami component, which follows v2 of the Origami specification',
                     origamiType: 'component',
-                    origamiCategory: 'components',
                     brands: [
                         'master',
                         'internal'
@@ -95,7 +94,6 @@ exports.seed = async database => {
                 origami: {
                     description: 'An example Origami component, which follows v2 of the Origami specification',
                     origamiType: 'component',
-                    origamiCategory: 'components',
                     keywords: 'example, mock',
                     origamiVersion: '2.0',
                     support: 'https://github.com/Financial-Times/o-example-component-v2/issues',
@@ -137,7 +135,6 @@ exports.seed = async database => {
                 origami: {
                     description: 'An example Origami component, which follows v2 of the Origami specification',
                     origamiType: 'component',
-                    origamiCategory: 'components',
                     keywords: 'example, mock',
                     origamiVersion: '2.0',
                     support: 'https://github.com/Financial-Times/o-example-component-v2/issues',

--- a/models/version.js
+++ b/models/version.js
@@ -305,6 +305,9 @@ function initModel(app) {
 			},
 
 			// Get the Origami sub-type (category) for the version
+			// Spec v1 components/modules have a sub-type (category),
+			// this was dropped in spec v2:
+			// https://github.com/Financial-Times/origami/pull/120
 			sub_type() {
 				const manifests = this.get('manifests') || {};
 				if (manifests.origami && manifests.origami.origamiCategory && typeof manifests.origami.origamiCategory === 'string') {

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -24,11 +24,11 @@
 	// The GitHub URL for the repo
 	"url": "https://github.com/Financial-Times/repo-name",
 
-	// The repo type, as outlined in the Origami Spec
+	// The repo type, as outlined in the Origami Specification
 	"type": "module",
 
-	// The repo category, as outlined in the Origami Spec (under origamiCategory).
-	// Set to `null` when the repo type is not `module`
+	// The repo category, as outlined in the Origami Specification v1 (under origamiCategory).
+	// Set to `null` for more recent versions of projects released under v2 of the Origami Specification.
 	"subType": "component",
 
 	// The latest version of the repo


### PR DESCRIPTION
Also updates test fixtures.

https://github.com/Financial-Times/origami/pull/120