### PR TITLE
Fix spec v2 component Sass detection.

### DIFF
--- a/lib/create-version-from-ingestion/get-version-languages.js
+++ b/lib/create-version-from-ingestion/get-version-languages.js
@@ -53,16 +53,16 @@ module.exports = async function getVersionLanguages(
         mainPaths.push(packageManifest.main);
     }
 
-    // Sass: non-v1 components do not use Bower but will have an index Sass file.
+    // Sass: non-v1 components do not use Bower but will have a main.scss Sass file.
     if (component && !specV1Component) {
         const sassIndex = await githubClient.loadFile({
-            path: '_index.scss',
+            path: 'main.scss',
             ref: tag,
             owner,
             repo
         });
         if (sassIndex) {
-            mainPaths.push('_index.scss');
+            mainPaths.push('main.scss');
         }
     }
 


### PR DESCRIPTION
Check for `main.scss` not `_index.scss`, as `_index.scss` was
removed from spec v2.

https://github.com/Financial-Times/origami-website/pull/273/commits/aae52da4e7198a8b17d4417bbef5435bbcd2361a

This is currently not showing the o-layout beta SassDoc for example:
https://registry.origami.ft.com/components/o-layout@5.0.0-beta.0?brand=master