### PR TITLE
Update Build Service v3 URLs to remove the package namespace.

### DIFF
--- a/models/bundle.js
+++ b/models/bundle.js
@@ -25,14 +25,8 @@ function initModel(app) {
             buildServiceUrl = new URL(`https://www.ft.com/__origami/service/build/v2/bundles/${language}`);
             buildServiceUrl.searchParams.append('modules', `${version.get('name')}@${version.get('version')}`);
         } else {
-            const packageName = version.get('package_name');
-            if (!packageName) {
-                throw new Error(
-                    `Could not find package name for ${version.get('name')}@${version.get('version')} to update ` +
-                    'bundle stats.');
-            }
             buildServiceUrl = new URL(`https://www.ft.com/__origami/service/build/v3/bundles/${language}`);
-            buildServiceUrl.searchParams.append('components', `${packageName}@${version.get('version')}`);
+            buildServiceUrl.searchParams.append('components', `${version.get('name')}@${version.get('version')}`);
             buildServiceUrl.searchParams.append('system_code', 'origami-repo-data');
         }
         if (brand && language === 'css') {

--- a/models/version.js
+++ b/models/version.js
@@ -633,12 +633,12 @@ function initModel(app) {
 				htmlDemoUrl = new URL(`${liveDemoUrl.toString()}/html`);
 			} else {
 				liveDemoUrl = new URL('https://www.ft.com/__origami/service/build/v3/demo');
-				liveDemoUrl.searchParams.append('component', `${version.get('package_name')}@${version.get('version')}`);
+				liveDemoUrl.searchParams.append('component', `${version.get('name')}@${version.get('version')}`);
 				liveDemoUrl.searchParams.append('demo', demo.name);
 				liveDemoUrl.searchParams.append('system_code', 'origami-repo-data');
 
 				htmlDemoUrl = new URL('https://www.ft.com/__origami/service/build/v3/demo/html');
-				htmlDemoUrl.searchParams.append('component', `${version.get('package_name')}@${version.get('version')}`);
+				htmlDemoUrl.searchParams.append('component', `${version.get('name')}@${version.get('version')}`);
 				htmlDemoUrl.searchParams.append('demo', demo.name);
 				htmlDemoUrl.searchParams.append('system_code', 'origami-repo-data');
 			}

--- a/test/integration/models/bundle.test.js
+++ b/test/integration/models/bundle.test.js
@@ -18,21 +18,21 @@ describe('Bundle', () => {
 			lang: 'css',
 			contentLength: 500,
 			v2Path: `/v2/bundles/css?modules=${testRepoName}%40${v1SpecRelease}&brand=master`,
-			v3Path: `/v3/bundles/css?components=%40financial-times%2F${testRepoName}%40${v2SpecRelease}&system_code=origami-repo-data&brand=master`
+			v3Path: `/v3/bundles/css?components=${testRepoName}%40${v2SpecRelease}&system_code=origami-repo-data&brand=master`
 		},
 		{
 			brand: 'internal',
 			lang: 'css',
 			contentLength: 300,
 			v2Path: `/v2/bundles/css?modules=${testRepoName}%40${v1SpecRelease}&brand=internal`,
-			v3Path: `/v3/bundles/css?components=%40financial-times%2F${testRepoName}%40${v2SpecRelease}&system_code=origami-repo-data&brand=internal`
+			v3Path: `/v3/bundles/css?components=${testRepoName}%40${v2SpecRelease}&system_code=origami-repo-data&brand=internal`
 		},
 		{
 			brand: null,
 			lang: 'js',
 			contentLength: 200,
 			v2Path: `/v2/bundles/js?modules=${testRepoName}%40${v1SpecRelease}`,
-			v3Path: `/v3/bundles/js?components=%40financial-times%2F${testRepoName}%40${v2SpecRelease}&system_code=origami-repo-data`
+			v3Path: `/v3/bundles/js?components=${testRepoName}%40${v2SpecRelease}&system_code=origami-repo-data`
 		}
 	];
 

--- a/test/integration/routes/v1-repos-(id)-versions-(id)-demos.test.js
+++ b/test/integration/routes/v1-repos-(id)-versions-(id)-demos.test.js
@@ -378,20 +378,20 @@ describe('GET /v1/repos/:repoId/versions/:versionId/demos', () => {
 				assert.lengthEquals(response, 4);
 
 				const demo1 = response[0];
-				assert.strictEqual(demo1.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v3/demo?component=%40financial-times%2Fo-mock-component%403.0.0&demo=example1&system_code=origami-repo-data&brand=master');
-				assert.strictEqual(demo1.supportingUrls.html, 'https://www.ft.com/__origami/service/build/v3/demo/html?component=%40financial-times%2Fo-mock-component%403.0.0&demo=example1&system_code=origami-repo-data&brand=master');
+				assert.strictEqual(demo1.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v3/demo?component=o-mock-component%403.0.0&demo=example1&system_code=origami-repo-data&brand=master');
+				assert.strictEqual(demo1.supportingUrls.html, 'https://www.ft.com/__origami/service/build/v3/demo/html?component=o-mock-component%403.0.0&demo=example1&system_code=origami-repo-data&brand=master');
 
 				const demo2 = response[1];
-				assert.strictEqual(demo2.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v3/demo?component=%40financial-times%2Fo-mock-component%403.0.0&demo=example2&system_code=origami-repo-data&brand=master');
-				assert.strictEqual(demo2.supportingUrls.html, 'https://www.ft.com/__origami/service/build/v3/demo/html?component=%40financial-times%2Fo-mock-component%403.0.0&demo=example2&system_code=origami-repo-data&brand=master');
+				assert.strictEqual(demo2.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v3/demo?component=o-mock-component%403.0.0&demo=example2&system_code=origami-repo-data&brand=master');
+				assert.strictEqual(demo2.supportingUrls.html, 'https://www.ft.com/__origami/service/build/v3/demo/html?component=o-mock-component%403.0.0&demo=example2&system_code=origami-repo-data&brand=master');
 
 				const demo3 = response[2];
-				assert.strictEqual(demo3.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v3/demo?component=%40financial-times%2Fo-mock-component%403.0.0&demo=example-no-html&system_code=origami-repo-data&brand=master');
+				assert.strictEqual(demo3.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v3/demo?component=o-mock-component%403.0.0&demo=example-no-html&system_code=origami-repo-data&brand=master');
 				assert.isNull(demo3.supportingUrls.html);
 
 				const demo4 = response[3];
-				assert.strictEqual(demo4.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v3/demo?component=%40financial-times%2Fo-mock-component%403.0.0&demo=example-branded-demo&system_code=origami-repo-data&brand=master');
-				assert.strictEqual(demo4.supportingUrls.html, 'https://www.ft.com/__origami/service/build/v3/demo/html?component=%40financial-times%2Fo-mock-component%403.0.0&demo=example-branded-demo&system_code=origami-repo-data&brand=master');
+				assert.strictEqual(demo4.supportingUrls.live, 'https://www.ft.com/__origami/service/build/v3/demo?component=o-mock-component%403.0.0&demo=example-branded-demo&system_code=origami-repo-data&brand=master');
+				assert.strictEqual(demo4.supportingUrls.html, 'https://www.ft.com/__origami/service/build/v3/demo/html?component=o-mock-component%403.0.0&demo=example-branded-demo&system_code=origami-repo-data&brand=master');
 
 			});
 


### PR DESCRIPTION
https://github.com/Financial-Times/origami-build-service/pull/520