### PR TITLE
Support the latest Origami Specification v2 simplification.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
 		'es6': true
 	},
 	'parserOptions': {
-		'ecmaVersion': 2018
+		'ecmaVersion': 2020
 	},
 	'rules': {
 		'no-unused-vars': 2,

--- a/data/seed/demo/example-component-v2.js
+++ b/data/seed/demo/example-component-v2.js
@@ -47,22 +47,28 @@ exports.seed = async database => {
                 about: null,
                 imageSet: null,
                 origami: {
-                    description: 'An example Origami component, which follows v2 of the Origami specification',
-                    origamiType: 'component',
+                    origami: '2.0',
+                    type: 'component',
+                    status: 'active',
                     brands: [
                         'master',
                         'internal'
                     ],
-                    keywords: 'example, mock',
-                    origamiVersion: '2.0',
-                    support: 'https://github.com/Financial-Times/o-example-component-v2/issues',
-                    supportStatus: 'active',
                     demos: demos
                 },
                 package: {
                     name: '@financial-times/o-example-component-v2',
+                    description: 'An example Origami component, which follows v2 of the Origami specification',
+                    keywords: 'example, mock',
                     version: '1.0.0',
-                    browser: './main.js'
+                    type: 'module',
+                    browser: './main.js',
+                    license: 'MIT',
+                    bugs: {
+                        url: 'https://github.com/Financial-Times/o-example-component-v2/issues',
+                        email: 'origami.support@ft.com',
+                        slack: 'origami-support'
+                    }
                 }
             }),
             languages: JSON.stringify(['js']),
@@ -92,18 +98,24 @@ exports.seed = async database => {
                 about: null,
                 imageSet: null,
                 origami: {
-                    description: 'An example Origami component, which follows v2 of the Origami specification',
-                    origamiType: 'component',
-                    keywords: 'example, mock',
-                    origamiVersion: '2.0',
-                    support: 'https://github.com/Financial-Times/o-example-component-v2/issues',
-                    supportStatus: 'active',
+                    origami: '2.0',
+                    type: 'component',
+                    status: 'active',
                     demos: demos
                 },
                 package: {
                     name: '@financial-times/o-example-component-v2',
+                    description: 'An example Origami component, which follows v2 of the Origami specification',
+                    keywords: 'example, mock',
                     version: '1.1.0',
-                    browser: './main.js'
+                    type: 'module',
+                    browser: './main.js',
+                    license: 'MIT',
+                    bugs: {
+                        url: 'https://github.com/Financial-Times/o-example-component-v2/issues',
+                        email: 'origami.support@ft.com',
+                        slack: 'origami-support'
+                    }
                 }
             }),
             languages: JSON.stringify(['js']),
@@ -133,24 +145,31 @@ exports.seed = async database => {
                 about: null,
                 imageSet: null,
                 origami: {
-                    description: 'An example Origami component, which follows v2 of the Origami specification',
-                    origamiType: 'component',
-                    keywords: 'example, mock',
-                    origamiVersion: '2.0',
-                    support: 'https://github.com/Financial-Times/o-example-component-v2/issues',
-                    supportStatus: 'active',
+                    origami: '2.0',
+                    type: 'component',
+                    status: 'active',
                     demos: demos
                 },
                 package: {
                     name: '@financial-times/o-example-component-v2',
+                    description: 'An example Origami component, which follows v2 of the Origami specification',
+                    keywords: 'example, mock',
                     version: '2.0.0',
+                    type: 'module',
                     browser: './main.js',
+                    sass: './main.scss',
+                    license: 'MIT',
+                    bugs: {
+                        url: 'https://github.com/Financial-Times/o-example-component-v2/issues',
+                        email: 'origami.support@ft.com',
+                        slack: 'origami-support'
+                    },
                     peerDependencies: {
                         'mathsass': '^0.11.0'
                     }
                 },
             }),
-            languages: JSON.stringify(['js']),
+            languages: JSON.stringify(['js', 'scss']),
             markdown: JSON.stringify({
                 designGuidelines: 'TODO add mock design guidelines',
                 migrationGuide: null,

--- a/lib/create-version-from-ingestion/index.js
+++ b/lib/create-version-from-ingestion/index.js
@@ -105,16 +105,22 @@ module.exports = async function createVersionFromIngestion(ingestion, Version, g
 			githubClient
 		);
 
+        // Handle specification v1 and v2 manifests
+        const type = origamiManifestNormalised?.origamiType || origamiManifestNormalised?.type;
+        const status = origamiManifestNormalised?.status || origamiManifestNormalised?.status;
+        const email = origamiManifestNormalised?.supportContact?.email || packageManifest?.bugs?.email;
+        const slack = origamiManifestNormalised?.supportContact?.slack || (packageManifest?.bugs?.slack ? `financial-times/${packageManifest.bugs.slack}` : undefined);
+
 		// Create the new version
 		const version = new Version({
 			name: repo,
-			type: origamiManifestNormalised.origamiType,
+			type,
 			url,
 			tag,
 			languages: JSON.stringify(languages),
-			support_status: origamiManifestNormalised.supportStatus,
-			support_email: origamiManifestNormalised.supportContact.email,
-			support_channel: origamiManifestNormalised.supportContact.slack,
+			support_status: status,
+			support_email: email,
+            support_channel: slack,
 			manifests: {
 				about: aboutManifest,
 				bower: bowerManifest,

--- a/models/version.js
+++ b/models/version.js
@@ -257,8 +257,9 @@ function initModel(app) {
 			// Get the component's Origami Specification version
 			origami_version() {
 				const manifests = this.get('manifests') || {};
-				const hasOrigamiVersion = manifests.origami && manifests.origami.origamiVersion;
-				return hasOrigamiVersion ? `${manifests.origami.origamiVersion}` : '';
+				// Handle Origami spec v1 and v2 projects
+				const origamiVersion = manifests?.origami?.origamiVersion || manifests?.origami?.origami;
+				return origamiVersion ? `${origamiVersion}` : '';
 			},
 
 			// Get keywords for the version, falling back through different manifests

--- a/test/integration/seed/basic/01-component.js
+++ b/test/integration/seed/basic/01-component.js
@@ -13,7 +13,6 @@ exports.seed = async database => {
 				'internal'
 			],
 			keywords: 'keyword1, keyword2',
-			isMockManifest: true,
 			demos: [
 				{
 					name: 'example1',
@@ -61,6 +60,75 @@ exports.seed = async database => {
 			devDependencies: {
 				'mock-bower-dependency-3': '^1.2.3',
 				'mock-bower-dependency-4': '^4.5.6'
+			}
+		}
+	};
+
+	const manifestsV2 = {
+		origami: {
+			origami: '2.0',
+			type: 'component',
+			status: 'maintained',
+			brands: [
+				'master',
+				'internal'
+			],
+			demos: [
+				{
+					name: 'example1',
+					title: 'Example Demo 1',
+					description: 'This is an example demo'
+				},
+				{
+					name: 'example2',
+					title: 'Example Demo 2',
+					description: ''
+				},
+				{
+					invalid: true
+				},
+				'invalid',
+				{
+					name: 'example-hidden',
+					title: 'Example Hidden Demo',
+					description: 'This is an example hidden demo',
+					hidden: true
+				},
+				{
+					name: 'example-no-html',
+					title: 'Example No-HTML Demo',
+					description: 'This is an example demo without HTML to be displayed',
+					display_html: false
+				},
+				{
+					name: 'example-branded-demo',
+					title: 'Example Branded Demo',
+					description: 'This is an example demo for the "example-brand" brand',
+					brands: ['example-brand']
+				}
+			]
+		},
+		package: {
+			name: '@financial-times/o-mock-component',
+			description: 'An example Origami component, which follows v2 of the Origami specification',
+			keywords: 'keyword1, keyword2',
+			version: '2.0.0',
+			type: 'module',
+			browser: 'mock.js',
+			sass: 'mock.scss',
+			license: 'MIT',
+			bugs: {
+				url: 'https://github.com/Financial-Times/o-mock-component-v2/issues',
+				email: 'origami.support@ft.com',
+				slack: 'origami-support'
+			},
+			dependencies: {
+				'mock-npm-dependency-1': '^1.2.3',
+				'mock-npm-dependency-2': '^4.5.6'
+			},
+			devDependencies: {
+				'mock-npm-dependency-3': '^1.2.3',
+				'mock-npm-dependency-4': '^4.5.6'
 			}
 		}
 	};
@@ -187,15 +255,7 @@ exports.seed = async database => {
 			version_patch: 0,
 			version_prerelease: 0,
 			languages: JSON.stringify(['js', 'scss']),
-			manifests: JSON.stringify(Object.assign({}, manifestsV1, {
-				origami: Object.assign({}, manifestsV1.origami, {
-					origamiVersion: '2.0'
-				}),
-				package: {
-					'name': `@financial-times/${manifestsV1.origami.name}`,
-					'version': '3.0.0'
-				}
-			})),
+			manifests: manifestsV2,
 			markdown: JSON.stringify(markdown)
 		}
 	]);

--- a/test/integration/seed/basic/03-imageset.js
+++ b/test/integration/seed/basic/03-imageset.js
@@ -8,7 +8,6 @@ exports.seed = async database => {
 			name: 'o-mock-imageset',
 			origamiType: 'imageset',
 			origamiVersion: 1,
-			isMockManifest: true
 		},
 		imageSet: {
 			scheme: 'ftmock',


### PR DESCRIPTION
Map v2 manifest changes to the existing repo data API.

I've chosen to map properties across the codebase opportunistically
rather than refactor, as we intend to overhaul or delete repo-data.

https://github.com/Financial-Times/origami-website/pull/359