### PR TITLE
Remove some v2 spec references

### DIFF
--- a/data/seed/demo/example-component-v2.js
+++ b/data/seed/demo/example-component-v2.js
@@ -47,7 +47,7 @@ exports.seed = async database => {
                 about: null,
                 imageSet: null,
                 origami: {
-                    description: 'An example Origami component, which follows v2 of the Origami specification',
+                    description: 'An example Origami component, which does not follow v1 of the component specification',
                     origamiType: 'component',
                     brands: [
                         'master',
@@ -92,7 +92,7 @@ exports.seed = async database => {
                 about: null,
                 imageSet: null,
                 origami: {
-                    description: 'An example Origami component, which follows v2 of the Origami specification',
+                    description: 'An example Origami component, which does not follow v1 of the component specification',
                     origamiType: 'component',
                     keywords: 'example, mock',
                     origamiVersion: '2.0',
@@ -133,7 +133,7 @@ exports.seed = async database => {
                 about: null,
                 imageSet: null,
                 origami: {
-                    description: 'An example Origami component, which follows v2 of the Origami specification',
+                    description: 'An example Origami component, which does not follow v1 of the component specification',
                     origamiType: 'component',
                     keywords: 'example, mock',
                     origamiVersion: '2.0',

--- a/test/integration/seed/search/repos.js
+++ b/test/integration/seed/search/repos.js
@@ -64,7 +64,7 @@ exports.seed = async database => {
 			origami_version: '2.0',
 			manifests: {
 				origami: {
-					description: 'this follows the v2 origami specification',
+					description: 'this follows does not follow the only version of the Origami specification currently published, v1',
 					keywords: [],
 					origamiVersion: '2.0',
 					brands: []
@@ -79,7 +79,7 @@ exports.seed = async database => {
 			origami_version: '2.1',
 			manifests: {
 				origami: {
-					description: 'this follows the v2.1 origami specification',
+					description: 'this follows does not follow the only version of the Origami specification currently published, v1',
 					keywords: [],
 					origamiVersion: '2.1',
 					brands: []

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -28,7 +28,7 @@
 	"type": "module",
 
 	// The repo category, as outlined in the Origami Specification v1 (under origamiCategory).
-	// Set to `null` for more recent versions of projects released under v2 of the Origami Specification.
+	// Set to `null` for more recent versions of projects, which no longer use the sub type.
 	"subType": "component",
 
 	// The latest version of the repo


### PR DESCRIPTION
We decided to deprecate the spec, version 2.0 does not exist but
is set in the component manifest `origamiVersion`