### PR TITLE
docs: update docs to remove public origami build service v2 references

### DIFF
--- a/models/bundle.js
+++ b/models/bundle.js
@@ -58,7 +58,7 @@ function initModel(app) {
                 // - Compilation Error (560)
                 // - Conflict (409)
                 // - Bad Request (400)
-                // https://www.ft.com/__origami/service/build/v2/#api-reference
+                // https://www.ft.com/__origami/service/build/v3/docs/api
                 const buildServiceError = new Error(`Unable to load ${encoding || 'non-encoded'} bundle from ${buildServiceUrl.toString()}${error.status ? ` (status: ${error.status}).` : ` within ${timeout}ms.`}`);
                 buildServiceError.isRecoverable = error.status && [400, 409, 560].includes(error.status) ? false : true;
                 throw buildServiceError;

--- a/views/api/repositories.html
+++ b/views/api/repositories.html
@@ -237,7 +237,7 @@
 	"brand": "core",
 
 	// The Origami Build Service url for this bundle.
-	"url": "https://www.ft.com/__origami/service/build/v2/bundles/css?modules=x-xxx",
+	"url": "https://www.ft.com/__origami/service/build/v3/bundles/css?components=x-xxx@x.x.x&brand=xxx&system_code=xxx",
 
 	// The size of this bundle in bytes; wth no compression "raw", and "gzip" compression
 	"sizes": {


### PR DESCRIPTION
Closes: https://github.com/Financial-Times/origami-repo-data/issues/356

Remaining OBS V2 references handle component injestion (V1 components). 
This can be removed when we decomission Build Service v2 / Bower but is as
well to stay until we decomission repo-data itself, along with the component
registry, as we move to storybook + bizops.