### PR TITLE
docs: update readme to consider new doppler integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ Get information about Origami repositories. See [the production service][product
   - [Running Locally](#running-locally)
   - [Configuration](#configuration)
     - [One time only](#one-time-only)
-    - [Required everywhere](#required-everywhere)
-    - [Required in Heroku](#required-in-heroku)
-    - [Required locally](#required-locally)
+    - [Heroku environment variables](#heroku-environment-variables)
+    - [Add secrets locally](#add-secrets-locally)
     - [Headers](#headers)
   - [Database](#database)
   - [Operational Documentation](#operational-documentation)
@@ -80,41 +79,43 @@ We configure Origami Repo Data using environment variables. In development, conf
 
 ### One time only
 
-  * `ENABLE_SETUP_STEP`: Set to `true` in order to allow the creation of an admin key using the `/v1/setup` endpoint. Once a key has been created this way, this configuration should be removed for security reasons.
+- `ENABLE_SETUP_STEP`: Set to `true` in order to allow the creation of an admin key using the `/v1/setup` endpoint. Once a key has been created this way, this configuration should be removed for security reasons.
 
-### Required everywhere
+### Heroku environment variables
 
-  * `BUILD_SERVICE_URL`: The url of the Origami Build Service to use for component urls such as demos.
-  * `DATABASE_URL`: A PostgreSQL connection string, with write permission on a database
-  * `GITHUB_AUTH_TOKEN`: A GitHub auth token which has read access to all Financial Times repositories.
-  * `NPM_REGISTRY`: The url of the npmjs registry to use when ingesting via npm.
-  * `NODE_ENV`: The environment to run the application in. One of `production`, `development` (default), or `test` (for use in automated tests).
-  * `PORT`: The port to run the application on.
+- `CHANGE_API_KEY`: The change-log API key to use when creating and closing change-logs.
+- `CMDB_API_KEY`: The CMDB API key to use when updating health checks and the application runbook
+- `DATABASE_URL`: A PostgreSQL connection string, with write permission on a database (optional locally)
+- `FASTLY_PURGE_API_KEY`: A Fastly API key which is used to purge URLs (when somebody POSTs to the `/purge` endpoint)
+- `GITHUB_AUTH_TOKEN`: A GitHub auth token which has read access to all Financial Times repositories.
+- `GRAPHITE_API_KEY`: The FT's internal Graphite API key.
+- `PURGE_API_KEY`: The API key to require when somebody POSTs to the `/purge` endpoint. This should be a non-memorable string, for example a UUID
+- `REGION`: The region the application is running in. One of `QA`, `EU`, or `US`
+- `RELEASE_LOG_ENV`: The Salesforce environment to include in change-logs. One of `Test` or `Production`
+- `SENTRY_DSN`: The Sentry URL to send error information to.
+- `SLACK_ANNOUNCER_AUTH_TOKEN`: The Slack auth token to use when announcing new repo versions on Slack
+- `SLACK_ANNOUNCER_CHANNEL_ID`: The Slack channel to announce new repo versions in (unique ID, not channel name)
 
-### Required in Heroku
+### Add secrets locally
 
-  * `CMDB_API_KEY`: The CMDB API key to use when updating health checks and the application runbook
-  * `FASTLY_PURGE_API_KEY`: A Fastly API key which is used to purge URLs (when somebody POSTs to the `/purge` endpoint)
-  * `GRAPHITE_API_KEY`: The FT's internal Graphite API key.
-  * `PURGE_API_KEY`: The API key to require when somebody POSTs to the `/purge` endpoint. This should be a non-memorable string, for example a UUID
-  * `REGION`: The region the application is running in. One of `QA`, `EU`, or `US`
-  * `CHANGE_API_KEY`: The change-log API key to use when creating and closing change-logs.
-  * `RELEASE_ENV`: The Salesforce environment to include in change-logs. One of `Test` or `Production`
-  * `SENTRY_DSN`: The Sentry URL to send error information to.
-  * `SLACK_ANNOUNCER_AUTH_TOKEN`: The Slack auth token to use when announcing new repo versions on Slack
-  * `SLACK_ANNOUNCER_CHANNEL_ID`: The Slack channel to announce new repo versions in (unique ID, not channel name)
-  * `NPM_CONFIG_LEGACY_PEER_DEPS`: Set to `true` to allow npm to install legacy peer dependencies of npm packages.
+Origami stores their secrets on Doppler to get them on your local development environment you will need to install the [Doppler CLI](https://docs.doppler.com/docs/enclave-installation), login in Doppler and run the following command to setup Doppler within the repo:
+```sh
+doppler setup
+```
 
-### Required locally
+Setup will ask you to select the project you want to use, select `origami-repo-data` and then select the `local` environment. Once setup is complete you can download the secrets to your local environment by running:
 
-  * `GRAFANA_API_KEY`: The API key to use when using Grafana push/pull
+```sh
+doppler secrets download --format --no-file > .env
+```
+
+**NOTE:** You might need to request contributor access to the Doppler project from the Origami team.
 
 ### Headers
 
 The service can also be configured by sending HTTP headers, these would normally be set in your CDN config:
 
-  * `FT-Origami-Service-Base-Path`: The base path for the service, this gets prepended to all paths in the HTML and ensures that redirects work when the CDN rewrites URLs.
-
+- `FT-Origami-Service-Base-Path`: The base path for the service, this gets prepended to all paths in the HTML and ensures that redirects work when the CDN rewrites URLs.
 
 ## Database
 


### PR DESCRIPTION
We migrated from Vault to Doppler and this PR updates readme based on the new setup

[OR-418](https://financialtimes.atlassian.net/jira/software/c/projects/OR/boards/1658?selectedIssue=OR-418)

[OR-418]: https://financialtimes.atlassian.net/browse/OR-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ