### PR TITLE
chore: Remove polyfill.io use

### DIFF
--- a/views/partials/html-head.html
+++ b/views/partials/html-head.html
@@ -31,7 +31,6 @@
 
 <link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-layout@^5.0.1,o-header-services@^5.0.0,o-footer-services@^4.0.1,o-syntax-highlight@^4.0.0,o-fonts@^5.0.0,o-message@^5.0.0,o-table@^9.0.0&brand=internal&system_code=origami-repo-data" />
 <link rel="stylesheet" href="main.css" />
-<script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
 <script>
 	(function(src) {
 		if (window.cutsTheMustard) {


### PR DESCRIPTION
Polyfill has not been FT owned for awhile, and has recently been sold. We are able to meet our browser support policy without it.